### PR TITLE
feat(markdown): resolve embedded asset URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ const fromCsv = await toMarkdownBytes(bytes, 'csv');
 
 // Or stop at the document model, which also carries embedded assets:
 const document = await toDocument(bytes);
+
+// Upload the assets, then render their URLs at the original positions:
+const assetUrls = Object.fromEntries(await Promise.all(
+  document.assets.map(async (asset) => [
+    asset.id,
+    await upload(asset.data, asset.mediaType),
+  ])
+));
+const withImages = await toMarkdownBytes(bytes, null, { assetUrls });
 ```
 
 > Full API reference: [node/README.md](node/README.md)
@@ -104,7 +113,7 @@ let document = anydoc::to_document(&bytes, None)?;
 
 - **One output for every format.** Each format parses into a shared document model and renders through a single Markdown serializer, so escaping, tables, heading anchors, and footnotes behave identically whether the input was a `.doc` from 2003 or a `.pptx` from yesterday.
 - **Full document structure.** Headings with anchors, bold/italic/strikethrough, inline code and code blocks, links and internal cross-references, bulleted/numbered/nested/task lists with the source's own numbering, tables with merged cells and header rows, block quotes, footnotes and endnotes, and speaker notes.
-- **Embedded assets.** Images and embedded objects render as their alt text in the Markdown, and the raw bytes stay available on the document model, tagged with their media type. Images with an external URL become ordinary Markdown images.
+- **Embedded assets.** Images and embedded objects render as their alt text by default, and the raw bytes stay available on the document model, tagged with their media type. Pass resolved asset URLs when rendering to place embedded images at their original document positions.
 - **Content-based format detection.** The format is read from the bytes themselves (PDF header, RTF open group, OLE stream names, ZIP package mimetype), so mislabeled files still convert correctly.
 - **Fast.** Pure Rust, no ML models, no external services. Median conversion time is under 5ms per document.
 - **Bindings that stay out of the way.** Node.js conversion runs on the libuv thread pool and never blocks the event loop; Python releases the GIL so other threads keep running. TypeScript types and Python stubs ship with the packages.

--- a/node/README.md
+++ b/node/README.md
@@ -52,6 +52,15 @@ const fromCsv = await toMarkdownBytes(bytes, 'csv');
 
 // Or stop at the document model, which also carries embedded assets:
 const document = await toDocument(bytes);
+
+// After uploading those assets, render their URLs at the original positions:
+const assetUrls = Object.fromEntries(await Promise.all(
+  document.assets.map(async (asset) => [
+    asset.id,
+    await upload(asset.data, asset.mediaType),
+  ])
+));
+const withImages = await toMarkdownBytes(bytes, null, { assetUrls });
 ```
 
 ## Format detection
@@ -66,7 +75,7 @@ formatFromPath('report.odt'); // 'odt'
 
 ## Images and embedded objects
 
-Markdown cannot embed bytes, so an embedded image renders as its alt text while the bytes stay on `document.assets`, tagged with a media type and the part they came from. Images that carry an external URL render as ordinary Markdown images.
+Markdown cannot embed bytes, so an embedded image renders as its alt text by default while the bytes stay on `document.assets`, tagged with a media type and the part they came from. After storing those bytes and obtaining URLs, pass `{ assetUrls: { [asset.id]: url } }` as the third argument to `toMarkdownBytes`; resolved images become ordinary Markdown images at their original document positions. Missing mappings keep the default alt-text behavior.
 
 Full behavior notes and benchmarks live in the [repository README](https://github.com/firecrawl/anydoc#readme).
 

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -196,6 +196,12 @@ export interface ListItem {
   markerLabel?: string
 }
 
+/** Options that customize Markdown rendering. */
+export interface MarkdownOptions {
+  /** Resolved URLs keyed by the string form of `Asset.id`. */
+  assetUrls?: Record<string, string>
+}
+
 /** The marker family a list uses in the source document. */
 export declare const enum MarkerKind {
   bullet = 'bullet',
@@ -263,6 +269,8 @@ export declare function toMarkdown(path: string): Promise<string>
 /**
  * Convert an in-memory document to Markdown. Without a format, it is
  * detected from the content, which signature-less formats (CSV) have to name
- * explicitly.
+ * explicitly. Pass resolved URLs in `options.assetUrls`, keyed by `Asset.id`,
+ * to render embedded images at their original document positions. Missing
+ * mappings keep the default alt-text rendering.
  */
-export declare function toMarkdownBytes(bytes: Uint8Array, format?: Format | undefined | null): Promise<string>
+export declare function toMarkdownBytes(bytes: Uint8Array, format?: Format | undefined | null, options?: MarkdownOptions | undefined | null): Promise<string>

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -2,10 +2,18 @@
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use std::collections::HashMap;
 
 mod document;
 
 pub use document::*;
+
+/// Options that customize Markdown rendering.
+#[napi(object)]
+pub struct MarkdownOptions {
+    /// Resolved URLs keyed by the string form of `Asset.id`.
+    pub asset_urls: Option<HashMap<String, String>>,
+}
 
 /// Input format, named after the extension that identifies it. Container
 /// variants that share a parser (`.docm`, `.xlsm`, `.ppsx`, ...) map onto
@@ -100,13 +108,20 @@ pub fn to_markdown(path: String) -> AsyncTask<MarkdownFileTask> {
 
 /// Convert an in-memory document to Markdown. Without a format, it is
 /// detected from the content, which signature-less formats (CSV) have to name
-/// explicitly.
+/// explicitly. Pass resolved URLs in `options.assetUrls`, keyed by `Asset.id`,
+/// to render embedded images at their original document positions. Missing
+/// mappings keep the default alt-text rendering.
 #[napi(ts_return_type = "Promise<string>")]
 pub fn to_markdown_bytes(
     bytes: Uint8Array,
     format: Option<Format>,
+    options: Option<MarkdownOptions>,
 ) -> AsyncTask<MarkdownBytesTask> {
-    AsyncTask::new(MarkdownBytesTask { bytes: bytes.to_vec(), format: format.map(Into::into) })
+    AsyncTask::new(MarkdownBytesTask {
+        bytes: bytes.to_vec(),
+        format: format.map(Into::into),
+        asset_urls: options.and_then(|options| options.asset_urls).unwrap_or_default(),
+    })
 }
 
 /// Parse an in-memory document into the document model, which also carries
@@ -139,6 +154,7 @@ impl Task for MarkdownFileTask {
 pub struct MarkdownBytesTask {
     bytes: Vec<u8>,
     format: Option<anydoc::Format>,
+    asset_urls: HashMap<String, String>,
 }
 
 impl Task for MarkdownBytesTask {
@@ -146,7 +162,15 @@ impl Task for MarkdownBytesTask {
     type JsValue = String;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        anydoc::to_markdown_bytes(&self.bytes, self.format).map_err(to_napi_error)
+        let mut options = anydoc::MarkdownOptions::default();
+        for (id, url) in &self.asset_urls {
+            let id = id
+                .parse::<usize>()
+                .map_err(|_| Error::from_reason(format!("invalid asset id: {id}")))?;
+            options.asset_urls.insert(anydoc::model::AssetId(id), url.clone());
+        }
+        anydoc::to_markdown_bytes_with_options(&self.bytes, self.format, &options)
+            .map_err(to_napi_error)
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/node/test.mjs
+++ b/node/test.mjs
@@ -41,6 +41,25 @@ test('toMarkdownBytes detects the format when none is named', async () => {
   assert.match(await toMarkdownBytes(await readFile(CSV), 'csv'), /\| --- \|/)
 })
 
+test('toMarkdownBytes resolves embedded asset URLs in place', async () => {
+  const bytes = await readFile(RICH)
+  const document = await toDocument(bytes, 'docx')
+  const image = document.assets.find((asset) => asset.mediaType === 'image/png')
+  assert.ok(image)
+
+  const legacy = await toMarkdownBytes(bytes, 'docx')
+  assert.equal(await toMarkdownBytes(bytes, 'docx', {}), legacy)
+  assert.match(legacy, /\ntiny dot image\n/)
+
+  const url = 'https://cdn.example/tiny dot.png'
+  const resolved = await toMarkdownBytes(bytes, null, {
+    assetUrls: { [image.id]: url },
+  })
+  assert.match(resolved, /\n!\[tiny dot image\]\(<https:\/\/cdn\.example\/tiny dot\.png>\)\n/)
+  assert.ok(resolved.indexOf('- Ship') < resolved.indexOf('![tiny dot image]'))
+  assert.ok(resolved.indexOf('![tiny dot image]') < resolved.indexOf('Embedded object:'))
+})
+
 test('toDocument exposes the document model', async () => {
   const document = await toDocument(await readFile(OUTLINE), 'docx')
   const heading = document.blocks.find((block) => block.kind === 'heading')

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,23 @@ mod shared;
 
 pub use error::ConvertError;
 
-use render::markdown::document_to_markdown;
+use render::markdown::{document_to_markdown, document_to_markdown_with_options};
 
+use std::collections::HashMap;
 use std::path::Path;
+
+/// Options that customize Markdown rendering without changing the parsed
+/// document model.
+#[derive(Debug, Clone, Default)]
+pub struct MarkdownOptions {
+    /// Resolved URLs for embedded assets, keyed by their [`model::AssetId`].
+    ///
+    /// A resolved image renders as an ordinary Markdown image at its original
+    /// document position. An unresolved image keeps the default behavior and
+    /// renders as alt text, so an empty map is byte-for-byte compatible with
+    /// [`to_markdown_bytes`].
+    pub asset_urls: HashMap<model::AssetId, String>,
+}
 
 /// Input format. Selects the parser; container variants that share a parser
 /// (docm, xlsm, ...) map onto these via [`Format::from_bytes`] or
@@ -116,13 +130,34 @@ pub fn to_markdown_bytes(
     bytes: &[u8],
     format: impl Into<Option<Format>>,
 ) -> Result<String, ConvertError> {
+    to_markdown_bytes_with_options(bytes, format, &MarkdownOptions::default())
+}
+
+/// Convert an in-memory document to Markdown with custom rendering options.
+/// Pass a [`Format`] to select the parser, or `None` to detect it from the
+/// content ([`Format::from_bytes`]).
+///
+/// Embedded images whose asset ids occur in [`MarkdownOptions::asset_urls`]
+/// render as Markdown images at their original document position. Missing
+/// mappings preserve the default alt-text rendering. Options have no effect
+/// on PDFs because their converter emits Markdown directly.
+pub fn to_markdown_bytes_with_options(
+    bytes: &[u8],
+    format: impl Into<Option<Format>>,
+    options: &MarkdownOptions,
+) -> Result<String, ConvertError> {
     let format = resolve_format(bytes, format.into())?;
     // PDFs convert to Markdown directly (pdf-inspector) without passing
     // through the document model.
     if format == Format::Pdf {
         return formats::pdf::to_markdown(bytes);
     }
-    Ok(document_to_markdown(&to_document(bytes, format)?))
+    let document = to_document(bytes, format)?;
+    if options.asset_urls.is_empty() {
+        Ok(document_to_markdown(&document))
+    } else {
+        Ok(document_to_markdown_with_options(&document, options))
+    }
 }
 
 /// Parse an in-memory document into the document model. Pass a [`Format`] to

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -100,7 +100,7 @@ fn render_inlines_mode(inlines: &[Inline], ctx: InlineContext, in_label: bool, r
                 }
             }
             Norm::Link { content, target } => render_link(content, target, ctx, rc, &mut out),
-            Norm::Image { alt, source } => render_image(alt, source, ctx, in_label, &mut out),
+            Norm::Image { alt, source } => render_image(alt, source, ctx, in_label, rc, &mut out),
             Norm::Anchor(id) => {
                 if let Some(html_id) = rc.anchors.html_id(id) {
                     let _ = write!(out, "<a id=\"{html_id}\"></a>");
@@ -153,18 +153,22 @@ fn render_image(
     source: &ImageSource,
     ctx: InlineContext,
     in_label: bool,
+    rc: &Ctx,
     out: &mut String,
 ) {
     match source {
-        ImageSource::External(url) => {
-            let alt =
-                escape_text(alt.trim(), ctx, EscapeOpts { in_label: true, ..Default::default() });
-            let _ = write!(out, "![{}]({})", alt, format_url(url));
-        }
-        // Embedded assets render as their alt text: Markdown cannot embed
-        // bytes, and the bytes stay available in `Document::assets`. A
-        // source-less image has only its alt text to offer.
-        ImageSource::Asset(_) | ImageSource::Unavailable => {
+        ImageSource::External(url) => render_image_url(alt, url, ctx, out),
+        ImageSource::Asset(id) => match rc.asset_urls.get(id) {
+            Some(url) => render_image_url(alt, url, ctx, out),
+            None if !alt.trim().is_empty() => out.push_str(&escape_text(
+                alt.trim(),
+                ctx,
+                EscapeOpts { in_label, ..Default::default() },
+            )),
+            None => {}
+        },
+        // A source-less image has only its alt text to offer.
+        ImageSource::Unavailable => {
             if !alt.trim().is_empty() {
                 out.push_str(&escape_text(
                     alt.trim(),
@@ -174,6 +178,11 @@ fn render_image(
             }
         }
     }
+}
+
+fn render_image_url(alt: &str, url: &str, ctx: InlineContext, out: &mut String) {
+    let alt = escape_text(alt.trim(), ctx, EscapeOpts { in_label: true, ..Default::default() });
+    let _ = write!(out, "![{}]({})", alt, format_url(url));
 }
 
 /// Emit a styled run, moving edge whitespace outside the delimiters.

--- a/src/render/markdown/mod.rs
+++ b/src/render/markdown/mod.rs
@@ -8,7 +8,10 @@ mod table;
 #[cfg(test)]
 mod tests;
 
-use crate::model::{Block, Document, Inline, List, MarkerKind, Note, TableKind, inlines_are_empty};
+use crate::MarkdownOptions;
+use crate::model::{
+    AssetId, Block, Document, Inline, List, MarkerKind, Note, TableKind, inlines_are_empty,
+};
 use anchors::{AnchorMap, resolve_anchors};
 use escape::{EscapeOpts, InlineContext, backtick_fence, escape_text};
 use inline::render_inlines;
@@ -35,10 +38,19 @@ type NoteNumbers = HashMap<String, usize>;
 pub(crate) struct Ctx {
     nums: NoteNumbers,
     anchors: AnchorMap,
+    asset_urls: HashMap<AssetId, String>,
 }
 
 pub fn document_to_markdown(doc: &Document) -> String {
-    let rc = Ctx { nums: number_notes(doc), anchors: resolve_anchors(doc) };
+    document_to_markdown_with_options(doc, &MarkdownOptions::default())
+}
+
+pub fn document_to_markdown_with_options(doc: &Document, options: &MarkdownOptions) -> String {
+    let rc = Ctx {
+        nums: number_notes(doc),
+        anchors: resolve_anchors(doc),
+        asset_urls: options.asset_urls.clone(),
+    };
     let mut parts: Vec<String> = doc.blocks.iter().filter_map(|b| render_block(b, &rc)).collect();
     let mut rendered_defs: HashSet<usize> = HashSet::new();
     let mut ordered: Vec<(&Note, usize)> =

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -1,7 +1,8 @@
-use super::document_to_markdown;
+use super::{document_to_markdown, document_to_markdown_with_options};
+use crate::MarkdownOptions;
 use crate::model::{
-    AnchorId, Block, Cell, Document, GridBuilder, ImageSource, Inline, LinkTarget, List, ListItem,
-    MarkerKind, Note, NoteKind, Style, Table, TableKind,
+    AnchorId, AssetId, Block, Cell, Document, GridBuilder, ImageSource, Inline, LinkTarget, List,
+    ListItem, MarkerKind, Note, NoteKind, Style, Table, TableKind,
 };
 
 fn doc(blocks: Vec<Block>) -> String {
@@ -469,6 +470,44 @@ fn image_alt_brackets_and_backslash_escaped() {
         source: ImageSource::External("https://e.com/i.png".into()),
     }])]);
     assert_eq!(md, "![a\\[b\\]c\\\\](https://e.com/i.png)\n");
+}
+
+#[test]
+fn embedded_image_without_url_keeps_alt_text() {
+    let document = Document {
+        blocks: vec![Block::Paragraph(vec![Inline::Image {
+            alt: "diagram".into(),
+            source: ImageSource::Asset(AssetId(0)),
+        }])],
+        notes: Vec::new(),
+        assets: Vec::new(),
+    };
+
+    assert_eq!(document_to_markdown(&document), "diagram\n");
+    assert_eq!(
+        document_to_markdown_with_options(&document, &MarkdownOptions::default()),
+        "diagram\n"
+    );
+}
+
+#[test]
+fn embedded_image_with_url_renders_in_place() {
+    let document = Document {
+        blocks: vec![Block::Paragraph(vec![
+            Inline::plain("before "),
+            Inline::Image { alt: "a[b]".into(), source: ImageSource::Asset(AssetId(7)) },
+            Inline::plain(" after"),
+        ])],
+        notes: Vec::new(),
+        assets: Vec::new(),
+    };
+    let mut options = MarkdownOptions::default();
+    options.asset_urls.insert(AssetId(7), "https://cdn.example/a b.png".into());
+
+    assert_eq!(
+        document_to_markdown_with_options(&document, &options),
+        "before ![a\\[b\\]](<https://cdn.example/a b.png>) after\n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add Rust `MarkdownOptions` and `to_markdown_bytes_with_options` for mapping embedded `AssetId` values to resolved URLs
- expose the same capability in Node as the optional third argument to `toMarkdownBytes`
- render resolved embedded images as ordinary Markdown images at their original document positions
- preserve the existing alt-text fallback for unresolved assets

## Motivation

Document ingestion pipelines often need to extract embedded assets, upload them to their own storage, and then reference those URLs in the final Markdown. Today they can read the bytes through `toDocument`, but preserving each image's original position requires reimplementing or copying the Markdown serializer.

The new option keeps serialization inside anydoc:

```js
const document = await toDocument(bytes)
const assetUrls = Object.fromEntries(await Promise.all(
  document.assets.map(async (asset) => [
    asset.id,
    await upload(asset.data, asset.mediaType),
  ])
))

const markdown = await toMarkdownBytes(bytes, null, { assetUrls })
```

Rust callers can use `MarkdownOptions::asset_urls` with `to_markdown_bytes_with_options`.

## Backward compatibility

- the existing Rust `to_markdown_bytes` API is unchanged
- the Node options argument is optional
- missing options, an empty map, and unresolved asset ids retain the current output byte-for-byte
- PDFs are unchanged because they already emit Markdown directly

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked` (173 unit tests, robustness test, and 8 snapshot tests passed; one local-samples test remains ignored as expected)
- `cd node && npm run build && npm test` (14/14 passed)
- verified the regenerated TypeScript declaration supports both legacy calls and `format = null` with options

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/anydoc/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788465978&installation_model_id=11126&pr_number=7&repository=firecrawl%2Fanydoc&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fanydoc%2Fpull%2F7&signature=97965eeb01e3f8f90b479de5600901661dd0b4eaa6e889308ff239d63bc8e790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->