### PR TITLE
feat(wasm): name the failure cause in a kind property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ name = "anydoc-wasm"
 version = "0.1.4"
 dependencies = [
  "anydoc",
+ "js-sys",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -21,6 +21,7 @@ wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
 
 [dependencies]
 anydoc = { path = ".." }
+js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde-wasm-bindgen = "0.6"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -97,7 +97,7 @@ pub fn format_from_path(path: &str) -> Option<Format> {
 /// detected from the content, which signature-less formats (CSV) have to name
 /// explicitly.
 #[wasm_bindgen(js_name = toMarkdownBytes)]
-pub fn to_markdown_bytes(bytes: &[u8], format: Option<Format>) -> Result<String, JsError> {
+pub fn to_markdown_bytes(bytes: &[u8], format: Option<Format>) -> Result<String, JsValue> {
     anydoc::to_markdown_bytes(bytes, format.map(anydoc::Format::from)).map_err(convert_error)
 }
 
@@ -107,13 +107,44 @@ pub fn to_markdown_bytes(bytes: &[u8], format: Option<Format>) -> Result<String,
 /// Unsupported for `pdf`: PDF conversion produces Markdown directly and has
 /// no document-model form; use `toMarkdownBytes`.
 #[wasm_bindgen(js_name = toDocument, unchecked_return_type = "Document")]
-pub fn to_document(bytes: &[u8], format: Option<Format>) -> Result<JsValue, JsError> {
+pub fn to_document(bytes: &[u8], format: Option<Format>) -> Result<JsValue, JsValue> {
     let document =
         anydoc::to_document(bytes, format.map(anydoc::Format::from)).map_err(convert_error)?;
     serde_wasm_bindgen::to_value(&Document::from(document))
-        .map_err(|error| JsError::new(&error.to_string()))
+        .map_err(|error| js_sys::Error::new(&error.to_string()).into())
 }
 
-fn convert_error(error: anydoc::ConvertError) -> JsError {
-    JsError::new(&error.to_string())
+/// Stable, machine-readable name for a `ConvertError` variant.
+///
+/// `ConvertError` is `#[non_exhaustive]`, so the catch-all keeps this compiling
+/// when a new variant lands.
+fn error_kind(error: &anydoc::ConvertError) -> &'static str {
+    use anydoc::ConvertError;
+    match error {
+        ConvertError::Unsupported(_) => "unsupported",
+        ConvertError::Malformed { .. } => "malformed",
+        ConvertError::Encrypted => "encrypted",
+        ConvertError::ResourceLimit { .. } => "resourceLimit",
+        ConvertError::MissingPart { .. } => "missingPart",
+        ConvertError::Io(_) => "io",
+        _ => "unsupported",
+    }
+}
+
+/// Build the thrown error, carrying the `ConvertError` variant as `kind`.
+///
+/// The message alone forces a caller to match on English prose to tell an
+/// encrypted document from an unreadable one. `kind` names the variant instead,
+/// so a caller can branch on the cause and keep the message for humans.
+fn convert_error(error: anydoc::ConvertError) -> JsValue {
+    let js_error = js_sys::Error::new(&error.to_string());
+    js_error.set_name("ConvertError");
+    // Setting a plain property on a fresh object cannot fail, so drop the result
+    // rather than panic inside an error path.
+    let _ = js_sys::Reflect::set(
+        &js_error,
+        &JsValue::from_str("kind"),
+        &JsValue::from_str(error_kind(&error)),
+    );
+    js_error.into()
 }

--- a/wasm/src/typescript.rs
+++ b/wasm/src/typescript.rs
@@ -8,6 +8,33 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(typescript_custom_section)]
 const TYPESCRIPT: &str = r#"
+/**
+ * Why a conversion failed, named after the Rust `ConvertError` variant.
+ *
+ * - `unsupported`   unknown format, or no convertible content. A scanned PDF
+ *                   with no text layer reports this.
+ * - `malformed`     structurally unusable input
+ * - `encrypted`     password-protected document
+ * - `resourceLimit` a fixed safety limit was exceeded
+ * - `missingPart`   a part required for any output is absent
+ * - `io`            the input could not be read
+ */
+export type ConvertErrorKind =
+  | 'unsupported'
+  | 'malformed'
+  | 'encrypted'
+  | 'resourceLimit'
+  | 'missingPart'
+  | 'io'
+
+/**
+ * The error `toMarkdownBytes` and `toDocument` throw. `kind` names the cause, so
+ * a caller can branch on it instead of matching the message text.
+ */
+export interface ConvertError extends Error {
+  kind: ConvertErrorKind
+}
+
 export interface Document {
   blocks: Array<Block>
   /**

--- a/wasm/test.mjs
+++ b/wasm/test.mjs
@@ -70,3 +70,29 @@ test('format detection reads content, extension, and path', () => {
 test('conversion errors throw with the crate error message', () => {
   assert.throws(() => toMarkdownBytes(new TextEncoder().encode('not a document'), 'docx'), /malformed|unsupported/)
 })
+
+const caught = (run) => {
+  try {
+    run()
+  } catch (error) {
+    return error
+  }
+  throw new Error('expected a throw')
+}
+
+test('conversion errors name the cause in kind', () => {
+  // `kind` lets a caller branch on the cause. Matching the message text is the
+  // alternative, and that breaks whenever the wording changes.
+  const unrecognized = caught(() => toMarkdownBytes(new TextEncoder().encode('not a document')))
+  assert.equal(unrecognized.name, 'ConvertError')
+  assert.equal(unrecognized.kind, 'unsupported')
+  assert.equal(typeof unrecognized.message, 'string')
+
+  const named = caught(() => toMarkdownBytes(new TextEncoder().encode('not a document'), 'docx'))
+  assert.ok(['malformed', 'unsupported'].includes(named.kind))
+
+  // Every variant maps to one of these names.
+  const kinds = ['unsupported', 'malformed', 'encrypted', 'resourceLimit', 'missingPart', 'io']
+  assert.ok(kinds.includes(unrecognized.kind))
+  assert.ok(kinds.includes(named.kind))
+})


### PR DESCRIPTION
A conversion error gives only a message. To tell an encrypted document from an unreadable one, a caller must match the message text. That match breaks when the wording changes.

This pull request adds a `kind` property to the error. The property holds the `ConvertError` variant. The values are `unsupported`, `malformed`, `encrypted`, `resourceLimit`, `missingPart`, and `io`. The message does not change, and it stays for people to read.

The error also takes the name `ConvertError`, which makes it easy to identify in a stack trace. The TypeScript definitions declare both types.

The `JsError` type cannot hold a property. Because of that limit, `toMarkdownBytes` and `toDocument` now return `Result<_, JsValue>`, and the code builds the error with `js_sys::Error`. This adds the `js-sys` crate, which is already part of the wasm-bindgen tree.

`ConvertError` is `#[non_exhaustive]`, so upstream can add a variant later. The `error_kind` function has a default branch, which keeps the crate correct when that happens.

`wasm/test.mjs` passes all 8 tests. One new test asserts the `kind` value twice: once for an input the code does not recognize, and once for an input that is malformed but named.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/anydoc/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788536410&installation_model_id=11126&pr_number=21&repository=firecrawl%2Fanydoc&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fanydoc%2Fpull%2F21&signature=694dad89db6b59c29c9d36db66f6bc5770533e64384dd54e3d73df718cce2cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->