### PR TITLE
feat(cli): add a Rust anydoc binary for cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npx @firecrawl/anydoc slides.pptx -o slides.md  # or to a file
 npx @firecrawl/anydoc - --format csv < data.csv # read stdin
 ```
 
-`npx` downloads the prebuilt binary for your platform on first run. For a permanent `anydoc` command, install globally with `npm install -g @firecrawl/anydoc`. Run `anydoc --help` for all options.
+`npx` downloads the prebuilt binary for your platform on first run. For a permanent `anydoc` command, install globally with `npm install -g @firecrawl/anydoc`, or build the same CLI from source with `cargo install anydoc`. Run `anydoc --help` for all options.
 
 ### Node.js
 

--- a/src/bin/anydoc.rs
+++ b/src/bin/anydoc.rs
@@ -1,0 +1,178 @@
+//! The `anydoc` CLI: convert one document to GitHub-Flavored Markdown.
+//!
+//! Mirrors the npm CLI (`node/cli.js`) flag for flag, so the two front ends
+//! stay interchangeable: same options, same help, same exit codes.
+
+use anydoc::Format;
+use std::io::{IsTerminal, Read, Write};
+use std::process::exit;
+
+const FORMATS: &str = "doc, docx, odt, pdf, ppt, pptx, rtf, epub, xlsx, ods, odp, csv";
+
+const USAGE_ERROR: i32 = 2;
+const CONVERSION_ERROR: i32 = 1;
+
+fn help() -> String {
+    format!(
+        "anydoc: convert documents to GitHub-Flavored Markdown
+
+Usage:
+  anydoc <file> [options]
+  anydoc - [options] < file
+
+Converts one document per invocation and writes the Markdown to stdout.
+Pass - as the input to read the document from stdin. Never prompts; all
+diagnostics go to stderr.
+
+Options:
+  -o, --output <path>    Write the Markdown to <path> instead of stdout
+  -f, --format <format>  Name the input format instead of detecting it:
+                         {FORMATS}
+                         (extension aliases like xls, docm, ppsx resolve
+                         to these)
+  -h, --help             Print this help and exit
+  -V, --version          Print the version and exit
+
+The format is detected from the file content; the file extension is the
+fallback for signature-less formats (CSV). stdin has no extension, so CSV
+input from stdin needs --format csv. Scanned or image-only PDFs need OCR,
+which anydoc does not do, and error as unsupported.
+
+Exit codes:
+  0  success
+  1  the document could not be read or converted
+  2  usage error: unknown option, missing input, or invalid --format
+
+Examples:
+  anydoc report.docx
+  anydoc slides.pptx -o slides.md
+  anydoc - --format csv < data.csv
+  curl -s https://example.com/paper.pdf | anydoc -
+"
+    )
+}
+
+fn fail(code: i32, message: &str) -> ! {
+    eprintln!("anydoc: {message}");
+    exit(code);
+}
+
+#[derive(Default)]
+struct Args {
+    input: Option<String>,
+    output: Option<String>,
+    format: Option<String>,
+}
+
+fn parse_args(argv: &[String]) -> Args {
+    let mut args = Args::default();
+    let mut positional_only = false;
+    let mut iter = argv.iter().peekable();
+    while let Some(raw) = iter.next() {
+        if positional_only || raw == "-" || !raw.starts_with('-') {
+            if args.input.is_some() {
+                fail(
+                    USAGE_ERROR,
+                    &format!("one document per invocation: unexpected second input '{raw}'"),
+                );
+            }
+            args.input = Some(raw.clone());
+            continue;
+        }
+        if raw == "--" {
+            positional_only = true;
+            continue;
+        }
+        // --opt=value carries its value inline; short options take the next
+        // argument.
+        let (arg, inline) = match raw.starts_with("--").then(|| raw.split_once('=')).flatten() {
+            Some((name, value)) => (name, Some(value.to_owned())),
+            None => (raw.as_str(), None),
+        };
+        let mut value = |arg: &str| {
+            inline.clone().unwrap_or_else(|| {
+                iter.next()
+                    .unwrap_or_else(|| fail(USAGE_ERROR, &format!("{arg} requires a value")))
+                    .clone()
+            })
+        };
+        match arg {
+            "-h" | "--help" => {
+                print!("{}", help());
+                exit(0);
+            }
+            "-V" | "--version" => {
+                println!("{}", env!("CARGO_PKG_VERSION"));
+                exit(0);
+            }
+            "-o" | "--output" => args.output = Some(value(arg)),
+            "-f" | "--format" => args.format = Some(value(arg)),
+            _ => fail(USAGE_ERROR, &format!("unknown option '{arg}' (see anydoc --help)")),
+        }
+    }
+    args
+}
+
+fn read_stdin() -> Vec<u8> {
+    let mut stdin = std::io::stdin();
+    if stdin.is_terminal() {
+        fail(USAGE_ERROR, "stdin is a terminal; pipe or redirect a document into anydoc -");
+    }
+    let mut bytes = Vec::new();
+    if let Err(e) = stdin.read_to_end(&mut bytes) {
+        fail(CONVERSION_ERROR, &e.to_string());
+    }
+    bytes
+}
+
+fn main() {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let args = parse_args(&argv);
+    let Some(input) = args.input else {
+        fail(
+            USAGE_ERROR,
+            "missing input: pass a document path, or - for stdin (see anydoc --help)",
+        );
+    };
+
+    let format = args.format.map(|name| {
+        Format::from_extension(&name).unwrap_or_else(|| {
+            fail(USAGE_ERROR, &format!("invalid format '{name}'; expected one of: {FORMATS}"))
+        })
+    });
+
+    let result = if input == "-" {
+        anydoc::to_markdown_bytes(&read_stdin(), format)
+    } else if let Some(format) = format {
+        match std::fs::read(&input) {
+            Ok(bytes) => anydoc::to_markdown_bytes(&bytes, format),
+            Err(e) => fail(CONVERSION_ERROR, &format!("{input}: {e}")),
+        }
+    } else {
+        anydoc::to_markdown(&input)
+    };
+    let markdown = result.unwrap_or_else(|e| {
+        // An unreadable file surfaces as ConvertError::Io; name the path,
+        // which the library-level message does not carry.
+        let message = match (&e, input.as_str()) {
+            (anydoc::ConvertError::Io(io), path) if path != "-" => format!("{path}: {io}"),
+            _ => e.to_string(),
+        };
+        fail(CONVERSION_ERROR, &message)
+    });
+
+    match args.output {
+        Some(path) => {
+            if let Err(e) = std::fs::write(&path, markdown) {
+                fail(CONVERSION_ERROR, &format!("{path}: {e}"));
+            }
+        }
+        None => {
+            // Downstream closing the pipe early (e.g. `anydoc big.xlsx | head`)
+            // is not a conversion failure.
+            if let Err(e) = std::io::stdout().write_all(markdown.as_bytes()) {
+                exit(if e.kind() == std::io::ErrorKind::BrokenPipe { 0 } else { CONVERSION_ERROR });
+            }
+        }
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,161 @@
+//! End-to-end tests for the `anydoc` CLI binary: argument handling, exit
+//! codes, and the conversion paths (file, stdin, explicit format, --output).
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn fixture(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(rel)
+}
+
+fn anydoc(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_anydoc")).args(args).output().unwrap()
+}
+
+fn anydoc_stdin(args: &[&str], input: &[u8]) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_anydoc"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(input).unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn stdout(output: &Output) -> &str {
+    str::from_utf8(&output.stdout).unwrap()
+}
+
+fn stderr(output: &Output) -> &str {
+    str::from_utf8(&output.stderr).unwrap()
+}
+
+#[test]
+fn help_prints_usage() {
+    for flag in ["-h", "--help"] {
+        let out = anydoc(&[flag]);
+        assert_eq!(out.status.code(), Some(0));
+        assert!(stdout(&out).contains("Usage:"), "help text missing from {flag}");
+    }
+}
+
+#[test]
+fn version_prints_crate_version() {
+    for flag in ["-V", "--version"] {
+        let out = anydoc(&[flag]);
+        assert_eq!(out.status.code(), Some(0));
+        assert_eq!(stdout(&out).trim(), env!("CARGO_PKG_VERSION"));
+    }
+}
+
+#[test]
+fn converts_a_file_to_stdout() {
+    let path = fixture("docx/handmade-numbering.docx");
+    let out = anydoc(&[path.to_str().unwrap()]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    assert!(!out.stdout.is_empty());
+}
+
+#[test]
+fn converts_stdin_with_named_format() {
+    let bytes = std::fs::read(fixture("csv/handmade-quoted.csv")).unwrap();
+    let out = anydoc_stdin(&["-", "--format", "csv"], &bytes);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    assert!(stdout(&out).contains('|'), "expected a Markdown table, got: {}", stdout(&out));
+}
+
+#[test]
+fn inline_format_value_is_accepted() {
+    let bytes = std::fs::read(fixture("csv/handmade-quoted.csv")).unwrap();
+    let out = anydoc_stdin(&["-", "--format=csv"], &bytes);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn format_alias_resolves() {
+    // xls resolves to the Excel parser; the fixture is a real xlsx.
+    let path = fixture("xlsx");
+    let file = std::fs::read_dir(&path)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .find(|p| p.extension().is_some_and(|e| e == "xlsx"));
+    let Some(file) = file else { return };
+    let out = anydoc(&[file.to_str().unwrap(), "-f", "xls"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn output_flag_writes_the_file() {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
+    std::fs::create_dir_all(dir).unwrap();
+    let dest = dir.join("cli-output.md");
+    let path = fixture("docx/handmade-numbering.docx");
+    let out = anydoc(&[path.to_str().unwrap(), "-o", dest.to_str().unwrap()]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    assert!(out.stdout.is_empty());
+    assert!(!std::fs::read_to_string(&dest).unwrap().is_empty());
+    std::fs::remove_file(&dest).unwrap();
+}
+
+#[test]
+fn stdin_without_format_is_a_conversion_error_for_csv() {
+    let bytes = std::fs::read(fixture("csv/handmade-quoted.csv")).unwrap();
+    let out = anydoc_stdin(&["-"], &bytes);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(stderr(&out).starts_with("anydoc: "), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn missing_file_is_a_conversion_error() {
+    let out = anydoc(&["no-such-document.docx"]);
+    assert_eq!(out.status.code(), Some(1));
+    let err = stderr(&out);
+    assert!(err.starts_with("anydoc: "), "stderr: {err}");
+    assert!(err.contains("no-such-document.docx"), "path missing from: {err}");
+}
+
+#[test]
+fn missing_input_is_a_usage_error() {
+    let out = anydoc(&[]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(stderr(&out).contains("missing input"), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn unknown_option_is_a_usage_error() {
+    let out = anydoc(&["--frobnicate"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(stderr(&out).contains("unknown option"), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn invalid_format_is_a_usage_error() {
+    let out = anydoc(&["-", "--format", "wat"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(stderr(&out).contains("invalid format"), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn second_input_is_a_usage_error() {
+    let out = anydoc(&["a.docx", "b.docx"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(stderr(&out).contains("second input"), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn missing_option_value_is_a_usage_error() {
+    let out = anydoc(&["a.docx", "--output"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(stderr(&out).contains("requires a value"), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn double_dash_ends_option_parsing() {
+    // After --, an option-looking argument is taken as the input path; the
+    // file does not exist, so this is a conversion error, not a usage error.
+    let out = anydoc(&["--", "--help"]);
+    assert_eq!(out.status.code(), Some(1));
+}


### PR DESCRIPTION
Closes #24.

Adds `src/bin/anydoc.rs` so `cargo install anydoc` yields the same CLI the npm package ships. The two front ends stay interchangeable — same options (`-o/--output`, `-f/--format`, `-h`, `-V`, `--`, `-` for stdin, `--opt=value` inline form), same help text, same exit codes (0 success / 1 conversion / 2 usage), and the same tolerances: stdin-on-a-TTY is a usage error, early-closed stdout (`anydoc big.xlsx | head`) exits 0.

Design notes:

- **No new dependencies.** Argument parsing is hand-rolled to mirror `node/cli.js` line for line rather than pulling in clap; `--format` validates through the existing `Format::from_extension`, so extension aliases (`xls`, `docm`, `ppsx`, …) resolve identically to the npm CLI.
- The one deliberate divergence: when a file can't be read, the error names the path (`anydoc: report.docx: No such file or directory…`) — the library-level `ConvertError::Io` message doesn't carry it, and on the CLI the filename is the useful part.
- `Cargo.toml` needs no changes: the bin is auto-discovered, `include = ["/src", …]` already packages it, and library consumers (`cargo add`) never build it.
- README gains a half-sentence pointing at `cargo install anydoc` in the CLI section.

Testing:

- `tests/cli.rs` drives the built binary end to end via `CARGO_BIN_EXE_anydoc`: file conversion, stdin with a named format, `--format=csv` inline form, alias resolution, `--output`, and every usage-error path (15 tests).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --locked` all pass locally (182 lib + 15 CLI + snapshot/robustness suites).
- Manually verified: docx/epub/csv fixtures convert byte-identically to the npm CLI paths, and `anydoc - --format csv < big.csv | head -c 80` exits 0 on the closed pipe.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/anydoc/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788592458&installation_model_id=11126&pr_number=29&repository=firecrawl%2Fanydoc&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fanydoc%2Fpull%2F29&signature=21f06cb42f60329da3db269ef702855b4d9b2463154585d2dfc87e9df62e1f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->