### PR TITLE
fix(presentations): separate slides with a thematic break

### DIFF
--- a/src/formats/odf/mod.rs
+++ b/src/formats/odf/mod.rs
@@ -75,11 +75,19 @@ fn parse_presentation(pres: &Element, ctx: &Ctx) -> Result<Vec<Block>, ConvertEr
         let mut body = Vec::new();
         let mut notes = Vec::new();
         walk_shapes(page, ctx, &mut title, &mut body, &mut notes)?;
-        blocks.append(&mut title);
-        blocks.append(&mut body);
+        let mut page_blocks: Vec<Block> = Vec::new();
+        page_blocks.append(&mut title);
+        page_blocks.append(&mut body);
         // Speaker notes are included (fixed policy), set off as a quote.
         if !notes.is_empty() {
-            blocks.push(Block::BlockQuote(notes));
+            page_blocks.push(Block::BlockQuote(notes));
+        }
+        // Separate pages with a thematic break — see the pptx parser for why.
+        if !page_blocks.is_empty() {
+            if !blocks.is_empty() {
+                blocks.push(Block::Rule);
+            }
+            blocks.append(&mut page_blocks);
         }
     }
     Ok(blocks)

--- a/src/formats/ppt/mod.rs
+++ b/src/formats/ppt/mod.rs
@@ -343,6 +343,10 @@ impl Extractor {
         let mut used = vec![false; notes.len()];
         let mut out = Vec::new();
         for (sid, blocks) in slides {
+            // Separate slides with a thematic break — see the pptx parser.
+            if !blocks.is_empty() && !out.is_empty() {
+                out.push(Block::Rule);
+            }
             out.extend(blocks);
             for (i, (nid, nblocks)) in notes.iter_mut().enumerate() {
                 if !used[i] && sid.is_some() && *nid == sid {

--- a/src/formats/pptx/mod.rs
+++ b/src/formats/pptx/mod.rs
@@ -163,12 +163,23 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
             instance_counter: &instance_counter,
             slide_anchors: &slide_anchors,
         };
+        // A slide is a container, not a page: its content must not run into
+        // the next slide's. A thematic break is the structural separator the
+        // model already has, and it is emitted BETWEEN slides only — never
+        // leading, never doubled by an empty slide.
+        let mut slide_blocks: Vec<Block> = Vec::new();
         if targeted.contains(slide_path)
             && let Some(anchor) = slide_anchors.get(slide_path)
         {
-            blocks.push(Block::Paragraph(vec![Inline::Anchor(anchor.clone())]));
+            slide_blocks.push(Block::Paragraph(vec![Inline::Anchor(anchor.clone())]));
         }
-        parse_shapes(sp_tree, &ctx, &mut blocks)?;
+        parse_shapes(sp_tree, &ctx, &mut slide_blocks)?;
+        if !slide_blocks.is_empty() {
+            if !blocks.is_empty() {
+                blocks.push(Block::Rule);
+            }
+            blocks.append(&mut slide_blocks);
+        }
 
         // Speaker notes, set off as a quote (fixed policy: included). The
         // tree is loaded before the `if let` so the package borrow is not
@@ -635,4 +646,118 @@ fn parse_table(tbl: &Element, ctx: &SlideCtx, blocks: &mut Vec<Block>) -> Result
     table.header_rows = resolve_header_rows(&table, header_rows);
     blocks.push(Block::Table(table));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const PRES_NS: &str = "http://schemas.openxmlformats.org/presentationml/2006/main";
+    const DRAWING_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    const REL_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    const PKG_REL_NS: &str = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+    /// A slide holding a single text box with `text`, or no shapes at all when
+    /// `text` is `None` — the "contributes nothing" case the separator must not
+    /// leave a dangling break for.
+    fn slide_xml(text: Option<&str>) -> String {
+        let body = match text {
+            Some(t) => format!(
+                r#"<p:sp><p:nvSpPr><p:cNvPr id="2" name="TextBox"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:p><a:r><a:t>{t}</a:t></a:r></a:p></p:txBody></p:sp>"#
+            ),
+            None => String::new(),
+        };
+        format!(
+            r#"<?xml version="1.0"?><p:sld xmlns:p="{PRES_NS}" xmlns:a="{DRAWING_NS}"><p:cSld><p:spTree>{body}</p:spTree></p:cSld></p:sld>"#
+        )
+    }
+
+    /// Minimal .pptx whose slides carry the given text bodies, in order. No
+    /// layout or master parts: every slide is title-less, which is exactly the
+    /// shape whose boundary used to vanish.
+    fn pptx_with_slides(slides: &[Option<&str>]) -> Vec<u8> {
+        let ids: String = (0..slides.len())
+            .map(|i| format!(r#"<p:sldId id="{}" r:id="rId{}"/>"#, 256 + i, i + 1))
+            .collect();
+        let rels: String = (0..slides.len())
+            .map(|i| {
+                format!(
+                    r#"<Relationship Id="rId{}" Type="{REL_NS}/slide" Target="slides/slide{}.xml"/>"#,
+                    i + 1,
+                    i + 1
+                )
+            })
+            .collect();
+
+        let mut w = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        let opts = zip::write::SimpleFileOptions::default();
+        let mut put = |name: &str, body: &str| {
+            w.start_file(name, opts).unwrap();
+            w.write_all(body.as_bytes()).unwrap();
+        };
+        put(
+            "_rels/.rels",
+            &format!(
+                r#"<?xml version="1.0"?><Relationships xmlns="{PKG_REL_NS}"><Relationship Id="rIdP" Type="{REL_NS}/officeDocument" Target="ppt/presentation.xml"/></Relationships>"#
+            ),
+        );
+        put(
+            "ppt/presentation.xml",
+            &format!(
+                r#"<?xml version="1.0"?><p:presentation xmlns:p="{PRES_NS}" xmlns:r="{REL_NS}"><p:sldIdLst>{ids}</p:sldIdLst></p:presentation>"#
+            ),
+        );
+        put(
+            "ppt/_rels/presentation.xml.rels",
+            &format!(
+                r#"<?xml version="1.0"?><Relationships xmlns="{PKG_REL_NS}">{rels}</Relationships>"#
+            ),
+        );
+        for (i, text) in slides.iter().enumerate() {
+            put(&format!("ppt/slides/slide{}.xml", i + 1), &slide_xml(*text));
+        }
+        w.finish().unwrap().into_inner()
+    }
+
+    fn blocks(slides: &[Option<&str>]) -> Vec<Block> {
+        parse(&pptx_with_slides(slides)).expect("minimal pptx should convert").blocks
+    }
+
+    #[test]
+    fn untitled_slides_are_separated() {
+        // The defect: with no title placeholder neither slide contributes a
+        // heading, so the two paragraphs used to be indistinguishable from two
+        // paragraphs of one slide.
+        let out = blocks(&[Some("first"), Some("second")]);
+        assert!(
+            matches!(out.as_slice(), [Block::Paragraph(_), Block::Rule, Block::Paragraph(_)]),
+            "expected a separator between the two slides, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn separator_never_leads() {
+        let out = blocks(&[Some("only")]);
+        assert!(
+            !matches!(out.first(), Some(Block::Rule)),
+            "a deck must not open with a separator, got {out:?}"
+        );
+        assert_eq!(out.len(), 1, "single slide should yield exactly its own content: {out:?}");
+    }
+
+    #[test]
+    fn empty_slides_leave_no_dangling_separator() {
+        // An empty slide contributes no blocks, so it must not push a break of
+        // its own — neither doubled between two real slides nor trailing.
+        let out = blocks(&[Some("first"), None, Some("second")]);
+        let rules = out.iter().filter(|b| matches!(b, Block::Rule)).count();
+        assert_eq!(rules, 1, "empty slide must not add a separator, got {out:?}");
+
+        let trailing = blocks(&[Some("first"), None]);
+        assert!(
+            !matches!(trailing.last(), Some(Block::Rule)),
+            "a trailing empty slide must not leave a dangling separator, got {trailing:?}"
+        );
+    }
 }

--- a/tests/snapshots/snapshots__odp__pres.odp.snap
+++ b/tests/snapshots/snapshots__odp__pres.odp.snap
@@ -11,6 +11,8 @@ Deck Title Slide
 
 > Speaker note for the intro slide.
 
+---
+
 Numbers Slide
 
 | Region | Total |

--- a/tests/snapshots/snapshots__ppt__handmade-multimaster.ppt.snap
+++ b/tests/snapshots/snapshots__ppt__handmade-multimaster.ppt.snap
@@ -4,4 +4,6 @@ expression: output
 ---
 - **Alpha master body text**
 
+---
+
 *Beta master body text*

--- a/tests/snapshots/snapshots__ppt__handmade-sparsenotes.ppt.snap
+++ b/tests/snapshots/snapshots__ppt__handmade-sparsenotes.ppt.snap
@@ -4,6 +4,8 @@ expression: output
 ---
 First slide text
 
+---
+
 Second slide text
 
 > Notes for the second slide

--- a/tests/snapshots/snapshots__ppt__pres.ppt.snap
+++ b/tests/snapshots/snapshots__ppt__pres.ppt.snap
@@ -12,6 +12,8 @@ Deck Title Slide
 
 > Speaker note for the intro slide.
 
+---
+
 Numbers Slide
 
 Region

--- a/tests/snapshots/snapshots__pptx__handmade-links.pptx.snap
+++ b/tests/snapshots/snapshots__pptx__handmade-links.pptx.snap
@@ -6,6 +6,8 @@ expression: output
 
 [External link](https://example.com/)
 
+---
+
 <a id="slide-2"></a>
 
 Second slide content

--- a/tests/snapshots/snapshots__pptx__pres.pptx.snap
+++ b/tests/snapshots/snapshots__pptx__pres.pptx.snap
@@ -12,6 +12,8 @@ Deck Title Slide
 
 > Speaker note for the intro slide.
 
+---
+
 Numbers Slide
 
 | Region | Total |


### PR DESCRIPTION
Fixes #31.

## What

Emits `Block::Rule` between slides in the three presentation parsers (`pptx`, `ppt`, `odp`), which previously concatenated every slide's blocks with nothing in between.

A slide's title becomes a `Heading`, so decks that title every slide read correctly by accident. A slide with no title placeholder contributes no structural block, so its content is indistinguishable from a continuation of the previous slide — two untitled slides in a row produce two adjacent paragraphs, and bullet lists from different slides merge into one list.

## Why a thematic break

No new concept and no page number: `Block::Rule` already exists, is already emitted for `<hr>` (`src/shared/html.rs:432`), and already renders as `---` (`src/render/markdown/mod.rs:201`).

This is deliberately not the pagination #26 declined. That issue settled that a `w:type="page"` break is layout and dropping it is correct. A slide is a container in the source model rather than a layout artifact, so its boundary is document structure.

## Shape of the change

Each parser now accumulates one slide into a local `Vec<Block>` and appends it only if non-empty, pushing a `Rule` first when output already exists. That gives two guarantees worth stating:

- never leading — no `---` before the first slide
- never doubled — a slide that produces no blocks (empty layout, chrome-only placeholders) cannot leave a dangling or repeated break

`ppt` already accumulated per slide, so it only needed the guard.

## Scope: core only, no binding changes

`Block::Rule` already exists and every binding already handles it, so nothing outside `src/formats/` needs to move:

| binding | maps `model::Block::Rule` | declares the `rule` kind |
|---|---|---|
| node | `node/src/document.rs:88` | `node/index.d.ts:60` |
| python | `python/src/document.rs:83` | `python/anydoc/_anydoc.pyi:84` |
| wasm | `wasm/src/document.rs:96` | `wasm/src/typescript.rs:47` |

No new `Block` variant, no public API change, no type-surface change. Confirmed end to end through the Python binding on the deck from the issue:

```python
>>> anydoc.to_document(data).blocks
['heading', 'rule', 'paragraph', 'rule', 'paragraph']   # kinds
```

## Tests

Three unit tests in `src/formats/pptx/mod.rs`, building minimal packages in memory in the style of the `sheet` module's tests — they pin the behaviour rather than just the output:

- `untitled_slides_are_separated` — the defect itself: two title-less slides must not read as one
- `separator_never_leads` — a deck must not open with `---`, and a single slide yields only its own content
- `empty_slides_leave_no_dangling_separator` — a slide contributing no blocks must not add a break, neither doubled between two real slides nor trailing

## Verification

```
cargo fmt --all --check                                          clean
cargo clippy --workspace --all-targets --all-features -D warnings clean
cargo clippy -p anydoc-wasm --target wasm32-unknown-unknown       clean
cargo test --locked                                              194 passed, 0 failed
python -m unittest discover -s tests                             9 passed
```

Snapshot delta is 6 added `---` lines and 6 added blank lines across 6 snapshots, with **zero removals** — no content changed, only separators appeared:

```
tests/snapshots/snapshots__odp__pres.odp.snap                  | 2 ++
tests/snapshots/snapshots__ppt__handmade-multimaster.ppt.snap  | 2 ++
tests/snapshots/snapshots__ppt__handmade-sparsenotes.ppt.snap  | 2 ++
tests/snapshots/snapshots__ppt__pres.ppt.snap                  | 2 ++
tests/snapshots/snapshots__pptx__handmade-links.pptx.snap      | 2 ++
tests/snapshots/snapshots__pptx__pres.pptx.snap                | 2 ++
```

Also checked by hand against a deck whose slides 2 and 3 have no title placeholder (the case in the issue) and against `tests/fixtures/ppt/pres.ppt`.

## Note

Happy to take this in a different direction if you would rather the boundary be expressed some other way, or scope it to a subset of the three parsers. The behaviour change is visible in output, so it is your call whether it belongs in a minor bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/anydoc/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788603077&installation_model_id=11126&pr_number=32&repository=firecrawl%2Fanydoc&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fanydoc%2Fpull%2F32&signature=d99110d5d2fb95185aad91b4885c4dc1794c50179f333da883e539a55e574de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->