### PR TITLE
fix(rtf): treat an escaped CR or LF as \par

### DIFF
--- a/src/formats/rtf/lexer.rs
+++ b/src/formats/rtf/lexer.rs
@@ -60,6 +60,15 @@ impl<'a> Lexer<'a> {
                     _ => Some(Token::Byte(b'\'')),
                 };
             }
+            // An escaped CR or LF is a paragraph mark: the spec makes `\`
+            // followed by a newline equivalent to `\par` (Cocoa's writer
+            // ends every body paragraph this way). Lexing it as the control
+            // word keeps every consumer's `par` handling in one place; the
+            // LF of a `\<CR><LF>` pair is then plain-text whitespace, which
+            // `next_token` already skips.
+            if b == b'\r' || b == b'\n' {
+                return Some(Token::Word { name: "par", param: None });
+            }
             return Some(Token::Symbol(b));
         }
         let start = self.pos;
@@ -166,6 +175,23 @@ mod tests {
         }
         assert_eq!(bin, br"}}{\\");
         assert_eq!((opens, closes), (1, 1));
+    }
+
+    #[test]
+    fn escaped_newline_lexes_as_par() {
+        // `\<LF>`, `\<CR><LF>` and `\<CR>` are each one paragraph mark.
+        let src = b"{\\rtf1 Alpha\\\nBeta\\\r\nGamma\\\rDelta}";
+        let mut lexer = Lexer::new(src);
+        let (mut pars, mut text) = (0, Vec::new());
+        while let Some(t) = lexer.next_token() {
+            match t {
+                Token::Word { name: "par", .. } => pars += 1,
+                Token::Byte(b) => text.push(b),
+                _ => {}
+            }
+        }
+        assert_eq!(pars, 3);
+        assert_eq!(text, b"AlphaBetaGammaDelta");
     }
 
     #[test]

--- a/src/formats/rtf/mod.rs
+++ b/src/formats/rtf/mod.rs
@@ -1045,6 +1045,18 @@ mod tests {
     }
 
     #[test]
+    fn escaped_newline_ends_the_paragraph() {
+        // Cocoa's writer ends body paragraphs with `\` + newline instead of
+        // a spelled-out \par; both forms must break paragraphs identically.
+        let escaped = "{\\rtf1 Alpha\\\nBeta\\\r\nGamma}";
+        let spelled = r"{\rtf1 Alpha\par Beta\par Gamma}";
+        let convert =
+            |src: &str| crate::to_markdown_bytes(src.as_bytes(), crate::Format::Rtf).unwrap();
+        assert_eq!(convert(escaped), "Alpha\n\nBeta\n\nGamma\n");
+        assert_eq!(convert(escaped), convert(spelled));
+    }
+
+    #[test]
     fn pict_hex_payload_becomes_an_asset() {
         let doc = parse(br"{\rtf1 before {\pict\pngblip 89504e470d0a1a0a} after}").unwrap();
         assert_eq!(doc.assets.len(), 1, "assets: {:?}", doc.assets);

--- a/tests/fixtures/rtf/handmade-newline.rtf
+++ b/tests/fixtures/rtf/handmade-newline.rtf
@@ -1,0 +1,11 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2822
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
+\pard\tx566\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 First Cocoa paragraph.\
+Second paragraph, ended by an escaped LF.\
+\b Bold third paragraph\b0 , mark escaped as CRLF.\
+Fourth paragraph with an \'e9 accent.}

--- a/tests/gen_fixtures.py
+++ b/tests/gen_fixtures.py
@@ -1359,6 +1359,28 @@ def merge_rtf():
 
 
 # ---------------------------------------------------------------------------
+# Cocoa RTF: TextEdit ends every body paragraph with `\` + newline instead of
+# a spelled-out \par; the escaped newline is a paragraph mark per the spec.
+
+def newline_rtf():
+    parts = [
+        b"{\\rtf1\\ansi\\ansicpg1252\\cocoartf2822",
+        b"\\cocoatextscaling0\\cocoaplatform0{\\fonttbl\\f0\\fswiss\\fcharset0 Helvetica;}",
+        b"{\\colortbl;\\red255\\green255\\blue255;}",
+        b"{\\*\\expandedcolortbl;;}",
+        b"\\paperw11900\\paperh16840\\margl1440\\margr1440\\vieww11520\\viewh8400\\viewkind0",
+        b"\\pard\\tx566\\pardirnatural\\partightenfactor0",
+        b"",
+        # Every `\` at end of line below is an escaped newline: one \par.
+        b"\\f0\\fs24 \\cf0 First Cocoa paragraph.\\",
+        b"Second paragraph, ended by an escaped LF.\\",
+        b"\\b Bold third paragraph\\b0 , mark escaped as CRLF.\\\r\nFourth paragraph with an \\'e9 accent.}",
+    ]
+    (OUT / "rtf").mkdir(parents=True, exist_ok=True)
+    (OUT / "rtf" / "handmade-newline.rtf").write_bytes(b"\n".join(parts))
+
+
+# ---------------------------------------------------------------------------
 # R10/R11: per-chapter CSS cascades and spine-only anchor classification
 
 def css_links_epub():
@@ -1739,6 +1761,7 @@ def main():
     order_pptx()
     css_links_epub()
     merge_rtf()
+    newline_rtf()
     multimaster_ppt()
     sparsenotes_ppt()
     tables_docx()

--- a/tests/snapshots/snapshots__rtf__handmade-newline.rtf.snap
+++ b/tests/snapshots/snapshots__rtf__handmade-newline.rtf.snap
@@ -1,0 +1,11 @@
+---
+source: tests/snapshots.rs
+expression: output
+---
+First Cocoa paragraph.
+
+Second paragraph, ended by an escaped LF.
+
+**Bold third paragraph**, mark escaped as CRLF.
+
+Fourth paragraph with an é accent.


### PR DESCRIPTION
Fixes #33.

## What

Lexes `\` immediately followed by CR or LF as the `par` control word, per the spec's reader conventions. This is the paragraph mark Cocoa's RTF writer (TextEdit, `NSAttributedString` exports) uses for essentially every body paragraph, so macOS-authored documents currently collapse into one paragraph — or into the first cell of a following table, since `tables.rs` runs its own token scan and misses the mark too.

## Shape of the change

The fix is in the lexer rather than the parser's symbol dispatch, deliberately: emitting `Token::Word { name: "par" }` gives every consumer — body text, notes, and the table scan — the existing `\par` handling in one place. A dispatcher-level fix would have left table cells broken.

The LF of a `\<CR><LF>` pair is then plain-text whitespace `next_token` already skips, so all three newline shapes yield exactly one mark each.

## Tests

- `escaped_newline_lexes_as_par` (lexer): `\<LF>`, `\<CR><LF>` and `\<CR>` each lex as one `par`; surrounding text bytes are untouched.
- `escaped_newline_ends_the_paragraph` (parser): the escaped form converts identically to the spelled-out `\par` form.
- New fixture `tests/fixtures/rtf/handmade-newline.rtf` + snapshot — Cocoa-shaped (`\cocoartf` prelude, color tables, escaped-LF and escaped-CRLF paragraph ends, a bold run, a `\'xx` escape), generated by `newline_rtf()` added to `tests/gen_fixtures.py`.

## Verification

```
cargo fmt --all --check                                            clean
cargo clippy --workspace --all-targets --all-features              clean
cargo test --locked                                                193 passed, 0 failed
```

(wasm32 clippy not run here — no wasm target installed locally.)

Snapshot delta: the new fixture's snapshot only; **zero existing snapshots changed**.

Minimal before/after (`{\rtf1 Alpha\<LF>Beta\<LF>Gamma}`):

```
before:  AlphaBetaGamma
after:   Alpha / Beta / Gamma as three paragraphs
```

Also checked against a real `textutil`-generated document with headings, nested lists and a table: before, the entire document text collapsed into the table's first cell; after, paragraphs, lists and the table come out as separate, correctly-typed blocks.

## Note

If you'd rather take this in your own direction, the issue carries everything needed to respec it — happy either way; the defect getting fixed is the point.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/anydoc/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788613665&installation_model_id=11126&pr_number=34&repository=firecrawl%2Fanydoc&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fanydoc%2Fpull%2F34&signature=c74c226371eb9c5b4b991034ae8321d2186498d15657e9d870dfd8fe6e997ce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->