### PR TITLE
feat(docker): add multi-stage CLI image and CI smoke test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Build artifacts — keep these out of the build context (they bloat it and can
+# leak local toolchain state). The broad **/ patterns cover the binding worktrees
+# (node/target, python/target, wasm/target) in addition to the root target/.
+target/
+**/target/
+
+# Node
+node_modules/
+**/node_modules/
+
+# Git
+.git/
+.gitignore
+
+# Non-redistributable / large corpora and binding build outputs
+bench/
+fuzz/target/
+python/dist/
+wasm/pkg/
+
+# Local agent / scratch state
+.claude/
+.zcode/
+thoughts/
+
+# Release archives
+*.tar.gz
+
+# CI / editor noise
+.editorconfig
+
+# Keep tests/fixtures/ — the CI smoke test converts one of these.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,29 @@ jobs:
       # Must run from the repo root: with python/ as cwd, the source anydoc/
       # package dir shadows the installed compiled module.
       - run: python -m unittest discover -s python/tests
+
+  docker:
+    name: Docker image (CLI)
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    # CI builds amd64 only; arm64 emulation under QEMU is slow and the
+    # Dockerfile is arch-neutral (verified locally on the darwin/arm64 host).
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: docker build -t anydoc .
+      - name: Smoke convert (non-empty Markdown)
+        run: |
+          set -o pipefail
+          docker run --rm -v "$PWD":/work -w /work anydoc convert tests/fixtures/docx/text.docx > /tmp/out.md
+          test -s /tmp/out.md
+      - name: No-args prints usage and exits non-zero
+        run: |
+          set +e
+          docker run --rm anydoc > /tmp/usage.txt 2>&1
+          code=$?
+          if [ "$code" -eq 0 ]; then
+            echo "::error::no-args invocation exited 0; expected non-zero"
+            exit 1
+          fi
+          grep -q 'usage:' /tmp/usage.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1
+#
+# Minimal CLI image for firecrawl/anydoc (issue #11).
+#
+# Builds the existing examples/convert.rs as the container entrypoint so a user
+# can run:
+#
+#   docker run --rm -v "$PWD":/work anydoc convert <file>
+#
+# Multi-stage: the builder carries the Rust toolchain and is discarded; the
+# runtime image holds only the compiled `convert` binary + a minimal glibc userland.
+# No Node/Python/WASM bindings, no network service, nothing baked in.
+#
+# NOTE on base images: the runtime is debian:bookworm-slim (glibc) rather than
+# alpine/musl. pdf-inspector (the only thing one might suspect of needing native
+# deps) is pure Rust, so musl is feasible, but glibc matches the CI runner
+# (ubuntu-2404) and a musl/static validation is deferred to a follow-up.
+
+########################################
+# Builder
+########################################
+FROM rust:1.88-bookworm AS build
+
+WORKDIR /srv
+
+# The root Cargo.toml is a workspace root (members = node/python/wasm), so
+# cargo refuses to load it unless every member manifest is present and parses.
+# Copy the manifests (root + the three tiny binding manifests) so the workspace
+# resolves, then stub every crate's src/lib.rs. This lets us pre-build the root
+# package's dependencies in a layer cached independently of the real sources.
+# We build only the root package (-p anydoc): the binding crates depend ON
+# anydoc, not the other way around, so their heavy deps (pyo3, napi,
+# wasm-bindgen) are never compiled — the stubs just have to parse.
+COPY Cargo.toml Cargo.lock ./
+COPY node/Cargo.toml ./node/Cargo.toml
+COPY python/Cargo.toml ./python/Cargo.toml
+COPY wasm/Cargo.toml ./wasm/Cargo.toml
+
+RUN mkdir -p src node/src python/src wasm/src \
+    && echo 'fn main() {}' > src/lib.rs \
+    && echo '' > node/src/lib.rs \
+    && echo '' > python/src/lib.rs \
+    && echo '' > wasm/src/lib.rs \
+    && cargo build --release --locked -p anydoc --lib \
+    && rm -rf src
+
+# Now copy the real sources and build the CLI example. `--locked` keeps the
+# build hermetic against Cargo.lock drift.
+COPY src/ ./src/
+COPY examples/ ./examples/
+COPY README.md LICENSE ./
+
+RUN cargo build --release --locked --example convert
+
+# The example binary lands here.
+# target/release/examples/convert
+
+########################################
+# Runtime
+########################################
+FROM debian:bookworm-slim
+
+# ca-certificates keeps future https fetches working; nothing else is needed at
+# runtime (documents are read from the mounted /work volume).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /srv/target/release/examples/convert /usr/local/bin/convert
+
+# Documents live on the host; the container converts from a mounted volume.
+WORKDIR /work
+
+ENTRYPOINT ["convert"]


### PR DESCRIPTION
Closes #11.

## Summary

Adds a minimal, multi-stage Docker image so `docker run --rm -v "$PWD":/work anydoc convert <file>` produces the same Markdown as the local `cargo run --example convert`. No bindings, no service, no registry push.

- **Builder** `rust:1.88-bookworm` compiles `examples/convert.rs` with `--release --locked` (PDF support is included by default — `pdf-inspector` is a plain dependency, no feature flags exist in `Cargo.toml`).
- **Runtime** `debian:bookworm-slim` carries only the `convert` binary + `ca-certificates`; `WORKDIR /work`, `ENTRYPOINT ["convert"]`. Documents are read from a mounted volume — nothing is baked in.
- **`.dockerignore`** keeps `target/`, `node_modules/`, binding build artifacts, and agent scratch dirs out of the context.
- **CI** adds a `docker` job that builds the image and runs one smoke conversion against `tests/fixtures/docx/text.docx`, so the Dockerfile cannot silently rot.

## Why debian over alpine

`pdf-inspector` and its deps (`lopdf`, `rayon`, `ttf-parser`) are pure Rust — there are no native deps that block musl — but glibc matches the CI runner (`ubuntu-2404`) and a fully-static musl validation is deferred to a follow-up rather than shipped unvalidated for v1.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo build --release --locked --example convert` ✅
- `docker build -t anydoc .` ✅ on `darwin/arm64`
- **Image size:** 33 MB (target was < 200 MB)
- **CLI parity:** `docker run … convert tests/fixtures/docx/text.docx` output is **byte-identical** to local `convert` (1316 bytes both).
- **Negative paths:** no-args → prints `usage:` + exit 1; missing file → clear error + exit 1.
- Branch rebased on current `main`.

## Scope / follow-ups (out of scope here)

- **No stdin (`-`) support:** `examples/convert.rs` always reads a file path — it has no stdin branch. This is deferred to #29 (the standalone `src/bin/anydoc.rs` CLI), which owns real stdin. Documented as a spec gap, not silently dropped.
- **arm64 in CI:** CI builds `amd64` only (QEMU emulation is slow); the Dockerfile is arch-neutral, verified locally on arm64.
- **Registry publishing** (GHCR/Docker Hub): maintainer decision, not included.
- Non-root `USER` hardening: deferred to a follow-up (the plan calls this out).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/anydoc/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788620740&installation_model_id=11126&pr_number=40&repository=firecrawl%2Fanydoc&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fanydoc%2Fpull%2F40&signature=a9a4ba5156f639b21ba76502ac77565fb2fc033a87a1b6c9465f4d119b1e29c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->