### PR TITLE
Fix invalid EPUB spine references

### DIFF
--- a/src/formats/epub/mod.rs
+++ b/src/formats/epub/mod.rs
@@ -44,12 +44,23 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
     // still publication content, and unusable parts degrade at parse time.
     // Intra-book links target these; links to any other resource stay
     // Relative.
-    let spine_hrefs: Vec<&str> = opf
-        .descendants_any("itemref")
-        .filter_map(|ir| ir.attr_any("idref"))
-        .filter_map(|idref| manifest.get(idref))
-        .map(|(href, _)| href.as_str())
-        .collect();
+    let mut spine_hrefs: Vec<&str> = Vec::new();
+    let mut spine_item_count = 0usize;
+    let mut failed = 0usize;
+    for itemref in opf.descendants_any("itemref") {
+        spine_item_count += 1;
+        let Some(idref) = itemref.attr_any("idref") else {
+            log::warn!("skipping spine item with no idref");
+            failed += 1;
+            continue;
+        };
+        let Some((href, _)) = manifest.get(idref) else {
+            log::warn!("skipping spine item whose idref {idref:?} is absent from the manifest");
+            failed += 1;
+            continue;
+        };
+        spine_hrefs.push(href);
+    }
     let spine_parts: HashSet<String> = spine_hrefs
         .iter()
         .filter_map(|href| path::resolve(&opf_path, href).ok().map(|t| t.path))
@@ -57,7 +68,6 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
 
     let assets = RefCell::new(AssetSink::new());
     let mut css_cache: HashMap<String, Option<String>> = HashMap::new();
-    let mut failed = 0usize;
     for href in &spine_hrefs {
         let chapter_path = match path::resolve(&opf_path, href) {
             Ok(t) => t.path,
@@ -92,7 +102,7 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
         doc.blocks.push(Block::Paragraph(vec![Inline::Anchor(chapter_path.clone())]));
         doc.blocks.extend(crate::shared::html::to_blocks(body, &css, &ctx)?);
     }
-    if !spine_hrefs.is_empty() && failed == spine_hrefs.len() {
+    if spine_item_count > 0 && failed == spine_item_count {
         return Err(ConvertError::malformed("no chapter in the book could be read"));
     }
 
@@ -204,5 +214,35 @@ fn scoped(chapter_path: &str, fragment: Option<&str>) -> AnchorId {
     match fragment {
         Some(f) if !f.is_empty() => format!("{chapter_path}#{f}"),
         _ => chapter_path.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+
+    fn epub(opf: &str) -> Vec<u8> {
+        let container = br#"<container><rootfiles>
+            <rootfile full-path="OEBPS/content.opf"/>
+            </rootfiles></container>"#;
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        for (name, bytes) in [
+            ("META-INF/container.xml", container.as_slice()),
+            ("OEBPS/content.opf", opf.as_bytes()),
+        ] {
+            writer.start_file(name, zip::write::SimpleFileOptions::default()).unwrap();
+            writer.write_all(bytes).unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    #[test]
+    fn unresolved_spine_itemref_is_malformed() {
+        let opf = r#"<package><manifest></manifest><spine>
+            <itemref idref="missing"/>
+            </spine></package>"#;
+        let err = parse(&epub(opf)).unwrap_err();
+        assert!(matches!(err, ConvertError::Malformed { .. }), "unexpected error: {err}");
     }
 }


### PR DESCRIPTION
## Summary

- Treat EPUB spine entries with missing `idref` values or dangling manifest references as failed chapters.
- Return `ConvertError::Malformed` when every declared spine entry is unusable.
- Preserve partial recovery when at least one spine chapter remains readable.
- Add a regression test for a spine entry whose `idref` is absent from the manifest.

## Root cause

Spine entries were collected through `filter_map`, so malformed or unresolved entries were
silently discarded before the parser's failed-chapter accounting. An EPUB containing only a
dangling spine reference therefore returned an empty successful document instead of a malformed
input error.

## Validation

- `cargo test formats::epub::tests::unresolved_spine_itemref_is_malformed -- --exact --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/anydoc/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788686186&installation_model_id=11126&pr_number=54&repository=firecrawl%2Fanydoc&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fanydoc%2Fpull%2F54&signature=a63b479604831e19076cbe5ebb0e3f14ababcaa08664621bf647c971f01e58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->