### PR TITLE
Prevent CLI output from overwriting input

### DIFF
--- a/node/cli.js
+++ b/node/cli.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
-const { readFile, writeFile } = require('node:fs/promises')
+const { readFile, stat, writeFile } = require('node:fs/promises')
+const { resolve } = require('node:path')
 
 const FORMATS = 'doc, docx, odt, pdf, ppt, pptx, rtf, epub, xlsx, ods, odp, csv'
 
@@ -113,10 +114,32 @@ async function readStdin() {
   return Buffer.concat(chunks)
 }
 
+async function referToSameFile(input, output) {
+  if (resolve(input) === resolve(output)) return true
+  try {
+    const [input_stats, output_stats] = await Promise.all([stat(input), stat(output)])
+    return input_stats.dev === output_stats.dev && input_stats.ino === output_stats.ino
+  } catch (error) {
+    if (error.code === 'ENOENT') return false
+    throw error
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2))
   if (args.input === null) {
     fail(USAGE_ERROR, 'missing input: pass a document path, or - for stdin (see anydoc --help)')
+  }
+  if (args.input !== '-' && args.output !== null) {
+    let same_file
+    try {
+      same_file = await referToSameFile(args.input, args.output)
+    } catch (error) {
+      fail(CONVERSION_ERROR, error.message)
+    }
+    if (same_file) {
+      fail(USAGE_ERROR, 'output path must differ from the input path')
+    }
   }
 
   // Loaded after argument handling so --help and --version work even where

--- a/node/test.mjs
+++ b/node/test.mjs
@@ -1,7 +1,7 @@
 // Smoke test: the bindings load and every entry point round-trips a fixture.
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { copyFile, link, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -106,6 +106,42 @@ test('cli writes to --output instead of stdout', async () => {
     assert.equal(code, undefined)
     assert.equal(stdout, '')
     assert.match(await readFile(out, 'utf8'), /^# /m)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('cli refuses to overwrite its input file', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'anydoc-cli-'))
+  try {
+    const input = join(dir, 'input.docx')
+    await copyFile(OUTLINE, input)
+    const before = await readFile(input)
+
+    const { code, stderr } = await runCli([input, '--output', input])
+
+    assert.equal(code, 2)
+    assert.match(stderr, /output.*input/i)
+    assert.deepEqual(await readFile(input), before)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('cli refuses to overwrite its input through a hard link', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'anydoc-cli-'))
+  try {
+    const input = join(dir, 'input.docx')
+    const output = join(dir, 'output.md')
+    await copyFile(OUTLINE, input)
+    await link(input, output)
+    const before = await readFile(input)
+
+    const { code, stderr } = await runCli([input, '--output', output])
+
+    assert.equal(code, 2)
+    assert.match(stderr, /output.*input/i)
+    assert.deepEqual(await readFile(input), before)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- reject `--output` paths that refer to the input file before conversion
- compare both normalized paths and file identity to cover hard links and symlinks
- add regression tests that verify the source bytes remain unchanged

## Root cause

The CLI converted the document and passed `--output` directly to `writeFile()` without
checking whether it referred to the input. Using the same path, or an alias of it,
therefore replaced the source document with generated Markdown.

## Impact

Invalid input/output combinations now fail with exit code 2 and leave the source file
untouched.

## Validation

- `npm test` (15 passed)
- `cargo test --locked` (217 passed, 1 ignored)
- direct-path and hard-link regression tests
- symlink smoke test with matching source SHA-256 before and after rejection

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/anydoc/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788687529&installation_model_id=11126&pr_number=55&repository=firecrawl%2Fanydoc&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fanydoc%2Fpull%2F55&signature=3d49c7f4ab00c53287545d284abd7eff8ee0e645e4b765716637f6bb0e79e812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->