### PR TITLE
Ignore local .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ __pycache__/
 # wasm-pack build output: pkg/ is the npm package, www/pkg/ the demo site copy
 /wasm/pkg/
 /wasm/www/pkg/
+
+# Local env (never commit secrets)
+.env
+.env.*
+!.env.example
+!**/.env.example


### PR DESCRIPTION
## Summary
- Add standard `.env` / `.env.*` ignore rules (with `.env.example` exceptions) so local secret files cannot be committed accidentally.
- Small hygiene fix; no runtime behavior change.

## Test plan
- [x] `git check-ignore .env` succeeds after change
- [ ] CI green