### PR TITLE
fix(markdown): escape pipes in code spans inside table cells

### DIFF
--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -205,7 +205,7 @@ fn render_text_run(
     }
     if !core.is_empty() {
         if style.code {
-            push_code_span(core, out);
+            push_code_span(core, ctx, out);
         } else {
             let mut open = String::new();
             if style.strike {
@@ -232,8 +232,10 @@ fn render_text_run(
     }
 }
 
-pub(crate) fn push_code_span(text: &str, out: &mut String) {
+pub(crate) fn push_code_span(text: &str, ctx: InlineContext, out: &mut String) {
     let text = text.replace('\n', " ");
+    // A raw pipe splits a GFM table cell even inside a code span.
+    let text = if ctx == InlineContext::TableCell { text.replace('|', "\\|") } else { text };
     let fence = backtick_fence(&text, 1);
     let pad = if text.starts_with('`') || text.ends_with('`') { " " } else { "" };
     let _ = write!(out, "{fence}{pad}{text}{pad}{fence}");

--- a/src/render/markdown/table.rs
+++ b/src/render/markdown/table.rs
@@ -166,7 +166,11 @@ fn cell_block_text(block: &Block, rc: &Ctx, parts: &mut Vec<String>) {
             let t = text.trim();
             if !t.is_empty() {
                 let mut s = String::new();
-                crate::render::markdown::inline::push_code_span(t, &mut s);
+                crate::render::markdown::inline::push_code_span(
+                    t,
+                    InlineContext::TableCell,
+                    &mut s,
+                );
                 parts.push(s);
             }
         }

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -321,6 +321,28 @@ fn code_block_pipes_cannot_split_table_cells() {
 }
 
 #[test]
+fn code_span_backslash_before_pipe_round_trips() {
+    // GFM's cell scanner never splits at a pipe preceded by a backslash
+    // (`table_cell = (escaped_char|[^|\r\n])+` is matched greedily, no parity
+    // counting), and unescape_pipes() strips exactly one backslash before each
+    // `|`. Emitting `\\|` for code text `\|` therefore renders back as `\|`.
+    let md = doc(vec![table_from(
+        vec![
+            vec![
+                Cell::from_inlines(vec![Inline::plain("Pattern")]),
+                Cell::from_inlines(vec![Inline::plain("Meaning")]),
+            ],
+            vec![
+                Cell::from_inlines(vec![styled("a \\| b", Style { code: true, ..Style::PLAIN })]),
+                Cell::from_inlines(vec![Inline::plain("BRE alternation")]),
+            ],
+        ],
+        1,
+    )]);
+    assert_eq!(md, "| Pattern | Meaning |\n| --- | --- |\n| `a \\\\| b` | BRE alternation |\n");
+}
+
+#[test]
 fn url_angle_brackets_are_encoded_without_bracketing() {
     let md = doc(vec![Block::Paragraph(vec![Inline::Link {
         content: vec![Inline::plain("link")],

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -296,6 +296,31 @@ fn url_pipes_cannot_split_table_cells() {
 }
 
 #[test]
+fn code_span_pipes_cannot_split_table_cells() {
+    let md = doc(vec![table_from(
+        vec![
+            vec![
+                Cell::from_inlines(vec![Inline::plain("Operator")]),
+                Cell::from_inlines(vec![Inline::plain("Meaning")]),
+            ],
+            vec![
+                Cell::from_inlines(vec![styled("a | b", Style { code: true, ..Style::PLAIN })]),
+                Cell::from_inlines(vec![Inline::plain("bitwise or")]),
+            ],
+        ],
+        1,
+    )]);
+    assert_eq!(md, "| Operator | Meaning |\n| --- | --- |\n| `a \\| b` | bitwise or |\n");
+}
+
+#[test]
+fn code_block_pipes_cannot_split_table_cells() {
+    let cell = Cell::new(vec![Block::CodeBlock { lang: None, text: "ls | wc -l".into() }]);
+    let md = doc(vec![table_from(vec![vec![cell]], 0)]);
+    assert_eq!(md, "|  |\n| --- |\n| `ls \\| wc -l` |\n");
+}
+
+#[test]
 fn url_angle_brackets_are_encoded_without_bracketing() {
     let md = doc(vec![Block::Paragraph(vec![Inline::Link {
         content: vec![Inline::plain("link")],


### PR DESCRIPTION
Fixes #84.

## What

`|` is escaped in table cells for plain text, emphasis, and URLs, but not for code spans, so a code span containing a pipe splits the GFM row and silently drops every column to its right.

`push_code_span()` took no `InlineContext`, so it could not know it was rendering inside a table cell. This gives it the context and escapes pipes there, matching what `escape_text()` already does at `escape.rs:82` and what `format_url()` does under the comment `// Raw pipes split GFM table cells.` (`escape.rs:151`).

Per the GFM spec (§4.10 Tables, [Example 200](https://github.github.com/gfm/#example-200)), escaping applies *inside* inline spans: `| b `\|` az |` → `<td>b <code>|</code> az</td>`.

## Why this way

The escape is applied in `push_code_span` rather than at the call sites so both paths that reach it are covered by one change — inline code runs (`inline.rs:208`) and cell-level `Block::CodeBlock` (`table.rs:169`). Behaviour outside `InlineContext::TableCell` is untouched, so paragraph-level code spans are unchanged.

The escape happens before `backtick_fence()` so the fence is computed on the text as emitted, and `\|` adds no backticks that could affect fence width.

## Diff

3 files, +34/−3 — 4 production lines and 2 regression tests. No reformatting, no unrelated changes.

## Tests

Two regression tests named after the existing `url_pipes_cannot_split_table_cells`, placed next to it: `code_span_pipes_cannot_split_table_cells` (styled run) and `code_block_pipes_cannot_split_table_cells` (cell-level `CodeBlock`).

Both fail before the change and pass after:

```
$ cargo test --lib pipes_cannot_split      # before
test render::markdown::tests::url_pipes_cannot_split_table_cells ... ok
test render::markdown::tests::code_block_pipes_cannot_split_table_cells ... FAILED
test render::markdown::tests::code_span_pipes_cannot_split_table_cells ... FAILED

  left: "| Operator | Meaning |\n| --- | --- |\n| `a | b` | bitwise or |\n"
 right: "| Operator | Meaning |\n| --- | --- |\n| `a \| b` | bitwise or |\n"

test result: FAILED. 1 passed; 2 failed
```

```
$ cargo test --locked                      # after
running 210 tests
test result: ok. 210 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running tests/robustness.rs
test result: ok. 1 passed; 0 failed

     Running tests/snapshots.rs
test result: ok. 8 passed; 0 failed; 1 ignored

   Doc-tests anydoc
test result: ok. 0 passed; 0 failed
```

No snapshot churn — `git status` is clean apart from the three files in this diff. The fixture corpus has no table cell containing code *and* a pipe, which is why this was never caught.

```
$ cargo fmt --all --check
(clean)
```

End-to-end on a minimal `.epub` with `<code>a | b</code>` and `<pre>ls | wc -l</pre>` in a two-column table:

```diff
 | Operator | Meaning |
 | --- | --- |
-| `a | b` | bitwise or |
-| `ls | wc -l` | shell pipeline |
+| `a \| b` | bitwise or |
+| `ls \| wc -l` | shell pipeline |
 | plain a \| b | escaped correctly |
```

Rendered through marked 18 with `gfm: true`, before → after:

```html
<tr><td>`a</td><td>b`</td></tr>                      <!-- before: "bitwise or" dropped -->
<tr><td><code>a | b</code></td><td>bitwise or</td></tr>  <!-- after: both columns intact -->
```

## Note on clippy

`cargo clippy --workspace --all-targets --all-features -- -D warnings` fails on my machine with 3 `collapsible_if` errors in `src/formats/rtf/tables.rs:293,302,422`. These are pre-existing and unrelated — I verified they reproduce identically on a clean checkout of `4e3089b` with the stash popped, and that file is not in this diff. It looks like a lint that newer clippy (1.95.0) flags but the toolchain CI pinned at release time did not. I left it alone to keep this diff minimal; happy to send a separate PR if you want it cleaned up.

Not run locally: the node, wasm, and python binding jobs. This change is confined to the Rust Markdown renderer and does not touch any binding surface.

---

This change was made with AI assistance; I reproduced the bug, reviewed the patch, and ran every test above locally myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes pipe characters in code spans inside GFM table cells so rows are not split. Before: a code span with | in a cell emitted a raw pipe and dropped columns to the right; now the pipe is emitted as \| and the table structure is preserved. Existing backslashes before | are preserved by emitting \\| so round-tripping remains correct.

- `push_code_span` now takes an `InlineContext` and escapes `|` only when `ctx == TableCell`; other contexts are unchanged.
- Centralizes the logic so both inline code runs and cell-level `CodeBlock` in table cells are handled.
- Escaping occurs before backtick fence calculation to keep fence width correct.
- Adds three regression tests, including a backslash-before-pipe round-trip case.

<sup>Written for commit d6fdf048bda9252c8318d54e4f74d476b7014b39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

