### PR TITLE
chore(deps): bump pdf-inspector to 1.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,9 +1071,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pdf-inspector"
-version = "0.1.8"
+version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2f755e49ad38eafbc82ba2bec1c59d57b5bf829b13a8f35e4263bc8913df3a"
+checksum = "1e024ae242c514e2adf6aee186678e0eabdc2e5ecfbb2159186881b4498593cb"
 dependencies = [
  "env_logger",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ csv = "1.4.0"
 flate2 = "1"
 encoding_rs = "0.8.35"
 log = "0.4"
-pdf-inspector = "0.1.8"
+pdf-inspector = "1.14.2"
 quick-xml = "0.41.0"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 


### PR DESCRIPTION
## Summary
- Bump the PDF frontend from pdf-inspector **0.1.8** to **1.14.2** (the current crates.io release; versions were unified at 1.14.0).
- `process_pdf_mem` / `PdfError` are unchanged, so `src/formats/pdf.rs` needed no API edits.
- Picks up parser resource bounds and extraction fixes from [pdf-inspector 1.14.2](https://github.com/firecrawl/pdf-inspector/releases/tag/v1.14.2): Form XObject expansion, CID `/W` / CMap / content-stream / detector / clustering caps, Form XObject `T*`/`TL`/`'`/`"`/`Tc`/`Tw`, and small-caps table merging.

## Test plan
- [x] `cargo test --locked`
- [x] `cargo fmt --all --check`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pdf-inspector` from 0.1.8 to 1.14.2 to enforce parser resource bounds and improve text extraction. Previously parsing could over-consume resources and miss Form XObject operators; now parsing is bounded and handles Form XObject operators and small-caps, which may slightly change extracted text.

**Review notes**
- No API changes; `process_pdf_mem` and `PdfError` remain the same. No edits to `src/formats/pdf.rs`.
- Expect improved stability on complex PDFs; verify extraction on fixtures with Form XObjects or CID fonts.
- No configuration or migration actions required.

<sup>Written for commit 20311d42074298b8b846099275eafa9a2061ced3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

