### PR TITLE
docs: list community Java bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![skills.sh](https://skills.sh/b/firecrawl/anydoc)](https://skills.sh/firecrawl/anydoc)
 
-Fast Rust library that converts documents (Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, and PDF) into clean GitHub-Flavored Markdown. Includes bindings for [Node.js](node/README.md), [Python](python/README.md), and the [browser](wasm/README.md) (WebAssembly).
+Fast Rust library that converts documents (Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, and PDF) into clean GitHub-Flavored Markdown. Includes bindings for [Node.js](node/README.md), [Python](python/README.md), and the [browser](wasm/README.md) (WebAssembly). Community bindings are listed [below](#community-bindings).
 
 Built by [Firecrawl](https://firecrawl.dev) to turn any office document into LLM-ready Markdown in single-digit milliseconds, with one consistent output no matter which format goes in. It powers [Firecrawl Parse](https://firecrawl.dev/parse), so if you'd rather not run it yourself, the hosted API gives you the same conversion plus our OCR models for the scanned pages anydoc can't read on its own.
 
@@ -123,6 +123,22 @@ let markdown = anydoc::to_markdown_bytes(&bytes, anydoc::Format::Csv)?;
 
 // Or stop at the document model, which also carries embedded assets:
 let document = anydoc::to_document(&bytes, None)?;
+```
+
+## Community bindings
+
+These are maintained outside this repository and are not official Firecrawl packages.
+
+### Java
+
+[anydoc-java](https://github.com/lihongjie0209/anydoc-java) is a JNI binding for Java 8+ (`toMarkdown` / `toDocument`). The fat JAR is on [Maven Central](https://central.sonatype.com/artifact/io.github.lihongjie0209/anydoc):
+
+```xml
+<dependency>
+  <groupId>io.github.lihongjie0209</groupId>
+  <artifactId>anydoc</artifactId>
+  <version>0.1.10</version>
+</dependency>
 ```
 
 ## Features


### PR DESCRIPTION
Adds a short **Community bindings** section so JVM users can find the unofficial Java 8 JNI wrapper without going through MCP or a subprocess.

- Repo: https://github.com/lihongjie0209/anydoc-java
- Maven Central: `io.github.lihongjie0209:anydoc:0.1.10`
- In-process `toMarkdown` / `toDocument`

The section is explicitly marked unofficial / not a Firecrawl package.

Related: #74

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Community bindings section to the README and links to it from the intro. It lists the unofficial Java 8+ JNI binding and Maven coordinates so JVM users can call toMarkdown/toDocument in-process without MCP or subprocesses.

Explicitly marks the Java binding as unofficial and not a Firecrawl package. Coordinates: `io.github.lihongjie0209:anydoc:0.1.10`. Docs-only change.

<sup>Written for commit 6847b768cf3e8bfe80a3a36f992674c1963ea72d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

