### PR TITLE
fix: pin lopdf to 0.42.0 to close RUSTSEC-2026-0187

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "flate2",
  "insta",
  "log",
+ "lopdf",
  "pdf-inspector",
  "quick-xml",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ flate2 = "1"
 encoding_rs = "0.8.35"
 log = "0.4"
 pdf-inspector = "1.14.2"
+# RUSTSEC-2026-0187: pdf-inspector -> lopdf <0.42.0 is vulnerable to a stack
+# overflow DoS via deeply nested PDF objects (SIGABRT, not catchable). Pin the
+# transitive dependency to the patched version to prevent resolution regressions.
+lopdf = "0.42.0"
 quick-xml = "0.41.0"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 


### PR DESCRIPTION
Closes #100

Explicitly pin `lopdf = "0.42.0"` (direct dependency with RUSTSEC-2026-0187 comment) so the patched version cannot silently regress and scanners can see it. `cargo build` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `lopdf` to 0.42.0 to remediate RUSTSEC-2026-0187 (stack overflow DoS). Previously `lopdf` was only transitive and could resolve <0.42.0; now it is a direct dependency pinned to the patched version to prevent resolution regressions and improve scanner visibility.

**Review notes**
- Adds `lopdf = "0.42.0"` to `Cargo.toml` with an advisory comment; updates `Cargo.lock`.
- No code or runtime behavior changes; this only affects dependency resolution and auditability.

<sup>Written for commit 2e3ee24318eb0bb4977addeed337f0bd31ac4e57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

