### PR TITLE
Add Kotlin/Android bindings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Applied whenever these targets are built, including via cargo-ndk.
+# 16 KB ELF segment alignment is required for Play on 64-bit Android 15+.
+[target.aarch64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.armv7-linux-androideabi]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.x86_64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,23 @@ jobs:
       # Must run from the repo root: with python/ as cwd, the source anydoc/
       # package dir shadows the installed compiled module.
       - run: python -m unittest discover -s python/tests
+
+  kotlin:
+    name: Kotlin bindings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.11.1'
+      - run: cargo test -p anydoc-kotlin --locked
+      - run: sh kotlin/scripts/generate-bindings.sh
+      - name: JVM binding tests
+        working-directory: kotlin/android/jvm-test
+        run: gradle test -Panydoc.nativeDir="${{ github.workspace }}/target/debug"

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -1,0 +1,183 @@
+# Build the Kotlin/Android AAR and, on demand, publish it as a Maven dependency.
+#
+# Every run uploads:
+#   - anydoc-<version>.aar          drop into app/libs/
+#   - maven-repo/                   host anywhere, or consume from the artifact
+#
+# On a v* tag: attach the AAR to the GitHub Release and publish GitHub Packages.
+# On a manual run with publish=true: publish GitHub Packages only (no release).
+name: Kotlin Android
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the AAR to GitHub Packages and attach it to the GitHub Release
+        type: boolean
+        default: false
+  push:
+    tags: ['v*']
+  pull_request:
+    paths:
+      - 'kotlin/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tests/fixtures/**'
+      - '.github/workflows/kotlin.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kotlin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-host:
+    name: Host library and JVM tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: '. -> target'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.11.1'
+      - name: Rust binding tests
+        run: cargo test -p anydoc-kotlin --locked
+      - name: Generate Kotlin bindings
+        run: sh kotlin/scripts/generate-bindings.sh
+      - name: JVM binding tests
+        working-directory: kotlin/android/jvm-test
+        run: gradle test -Panydoc.nativeDir="${{ github.workspace }}/target/debug"
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: jvm-test-reports
+          path: kotlin/android/jvm-test/build/reports/tests
+          if-no-files-found: ignore
+
+  build-aar:
+    name: Android AAR
+    needs: test-host
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: '. -> target'
+          key: android-ndk
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r28c
+          link-to-sdk: true
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: android-actions/setup-android@v3
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.11.1'
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked --version 4.1.2
+      - name: Generate Kotlin bindings
+        run: sh kotlin/scripts/generate-bindings.sh
+      - name: Cross-compile Android native libraries
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: sh kotlin/scripts/build-android.sh
+      - name: Read version
+        id: version
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "version=$(sh scripts/check-versions.sh "$GITHUB_REF_NAME")" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(sh scripts/check-versions.sh)" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Assemble AAR and local Maven repo
+        working-directory: kotlin/android
+        run: gradle :anydoc:assembleRelease :anydoc:publishReleasePublicationToLocalBuildRepository
+      - name: Stage artifacts
+        run: |
+          version='${{ steps.version.outputs.version }}'
+          mkdir -p staged/maven
+          cp kotlin/android/anydoc/build/outputs/aar/anydoc-release.aar "staged/anydoc-${version}.aar"
+          cp -a kotlin/android/build/maven/. staged/maven/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kotlin-aar
+          path: staged
+          if-no-files-found: error
+
+  publish:
+    name: Publish Maven / Release
+    needs: build-aar
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: kotlin-aar
+          path: dist
+      - name: Read version
+        id: version
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "version=$(sh scripts/check-versions.sh "$GITHUB_REF_NAME")" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(sh scripts/check-versions.sh)" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish the prebuilt Maven repo to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          repo="https://maven.pkg.github.com/${GITHUB_REPOSITORY}"
+          # Only versioned artifacts. GitHub Packages owns maven-metadata.xml;
+          # uploading Gradle's copy 409s or overwrites the registry index.
+          mapfile -t files < <(find dist/maven -type f \( -name '*.aar' -o -name '*.pom' -o -name '*-sources.jar' \))
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "error: no Maven artifacts under dist/maven" >&2
+            exit 1
+          fi
+          for file in "${files[@]}"; do
+            rel=${file#dist/maven/}
+            echo "PUT ${rel}"
+            curl -fL --retry 3 \
+              -X PUT \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              --upload-file "$file" \
+              "${repo}/${rel}"
+          done
+      - name: Attach AAR to the GitHub Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version='${{ steps.version.outputs.version }}'
+          if ! gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+          fi
+          gh release upload "$GITHUB_REF_NAME" "dist/anydoc-${version}.aar" --clobber
+          tar -C dist -czf "anydoc-${version}-maven-repo.tgz" maven
+          gh release upload "$GITHUB_REF_NAME" "anydoc-${version}-maven-repo.tgz" --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anydoc-kotlin"
+version = "0.1.9"
+dependencies = [
+ "anydoc",
+ "uniffi",
+ "zip",
+]
+
+[[package]]
 name = "anydoc-node"
 version = "0.1.0"
 dependencies = [
@@ -135,6 +144,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "askama"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
+]
+
+[[package]]
 name = "atoi_simd"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +206,15 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -202,6 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "calamine"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +289,38 @@ dependencies = [
  "quick-xml",
  "serde",
  "zip",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -287,6 +391,45 @@ dependencies = [
  "crypto-common 0.1.7",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codepage"
@@ -602,6 +745,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +863,23 @@ dependencies = [
  "r-efi",
  "rand_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -932,7 +1101,7 @@ dependencies = [
  "jiff",
  "log",
  "md-5",
- "nom",
+ "nom 8.0.0",
  "rand",
  "rangemap",
  "rayon",
@@ -959,6 +1128,12 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1035,6 +1210,16 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -1088,10 +1273,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1309,10 +1506,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1366,6 +1587,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,10 +1640,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -1421,6 +1673,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1461,6 +1719,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]
@@ -1529,6 +1796,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1854,127 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "uniffi"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "indexmap",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "toml",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1657,6 +2054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +2137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "zip"
 version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +2164,12 @@ name = "zlib-rs"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["node", "python", "wasm"]
+members = ["node", "python", "wasm", "kotlin"]
 # cargo-fuzz keeps its own lockfile and nightly-only dependencies.
 exclude = ["fuzz"]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![skills.sh](https://skills.sh/b/firecrawl/anydoc)](https://skills.sh/firecrawl/anydoc)
 
-Fast Rust library that converts documents (Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, and PDF) into clean GitHub-Flavored Markdown. Includes bindings for [Node.js](node/README.md), [Python](python/README.md), and the [browser](wasm/README.md) (WebAssembly).
+Fast Rust library that converts documents (Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, and PDF) into clean GitHub-Flavored Markdown. Includes bindings for [Node.js](node/README.md), [Python](python/README.md), [Kotlin/Android](kotlin/README.md), and the [browser](wasm/README.md) (WebAssembly).
 
 Built by [Firecrawl](https://firecrawl.dev) to turn any office document into LLM-ready Markdown in single-digit milliseconds, with one consistent output no matter which format goes in. It powers [Firecrawl Parse](https://firecrawl.dev/parse), so if you'd rather not run it yourself, the hosted API gives you the same conversion plus our OCR models for the scanned pages anydoc can't read on its own.
 
@@ -81,6 +81,26 @@ document = anydoc.to_document(data)
 ```
 
 > Full API reference: [python/README.md](python/README.md)
+
+### Kotlin / Android
+
+The [Kotlin Android](.github/workflows/kotlin.yml) workflow builds `dev.firecrawl:anydoc` — an AAR with the Rust parsers compiled to `.so` for `arm64-v8a`, `armeabi-v7a`, and `x86_64`. Run it, then depend on the published package or drop the AAR into `app/libs/`. See [kotlin/README.md](kotlin/README.md).
+
+```kotlin
+implementation("dev.firecrawl:anydoc:0.1.9")
+```
+
+```kotlin
+import dev.firecrawl.anydoc.Format
+import dev.firecrawl.anydoc.toDocument
+import dev.firecrawl.anydoc.toMarkdownBytes
+
+val markdown = toMarkdownBytes(bytes)
+val fromCsv = toMarkdownBytes(bytes, Format.CSV)
+val document = toDocument(bytes)
+```
+
+> Full API reference: [kotlin/README.md](kotlin/README.md)
 
 ### Browser (WebAssembly)
 
@@ -197,7 +217,7 @@ Format::from_extension("pptm"); // Some(Format::Pptx)
 Format::from_path(Path::new("report.odt")); // Some(Format::Odt)
 ```
 
-The same three functions exist in Node (`formatFromBytes`, ...) and Python (`anydoc.format_from_bytes`, ...).
+The same three functions exist in Node (`formatFromBytes`, ...), Python (`anydoc.format_from_bytes`, ...), and Kotlin (`formatFromBytes`, ...).
 
 ## Errors
 
@@ -224,7 +244,7 @@ match anydoc::to_markdown(path) {
 | `MissingPart`   | A part required for any meaningful output is absent                 |
 | `Io`            | The file could not be read, from `to_markdown` only                 |
 
-Node and wasm publish the variant name on `error.code`; Python raises one `anydoc.ConvertError` subclass per variant, or `OSError` when the file cannot be read.
+Node and wasm publish the variant name on `error.code`; Python raises one `anydoc.ConvertError` subclass per variant, or `OSError` when the file cannot be read. Kotlin throws one `ConvertException` subclass per variant, with the same name on `error.code`.
 
 ## How it works
 
@@ -253,15 +273,17 @@ cargo test
 cd node && npm install && npm run build && npm test
 cd python && pip install maturin && maturin develop && python -m unittest discover -s tests
 wasm-pack build wasm --release --target web --scope firecrawl && node --test wasm/test.mjs  # see wasm/README.md
+cargo test -p anydoc-kotlin && sh kotlin/scripts/generate-bindings.sh  # see kotlin/README.md
 ```
 
 A committed fixture corpus under `tests/fixtures/` is snapshot-tested, `tests/robustness.rs` mutation-tests every fixture, and `fuzz/` carries cargo-fuzz targets per format. The speed and quality benchmark lives in [`bench/`](bench/README.md).
 
-Releases are tagged `v<version>`, which publishes the crate, the npm package, and the PyPI wheels from [`.github/workflows/release.yml`](.github/workflows/release.yml). The version lives in three places, bumped together for a release:
+Releases are tagged `v<version>`, which publishes the crate, the npm package, and the PyPI wheels from [`.github/workflows/release.yml`](.github/workflows/release.yml). The version lives in these places, bumped together for a release:
 
 - [`Cargo.toml`](Cargo.toml): the crate
 - [`node/package.json`](node/package.json): the npm package
 - [`python/Cargo.toml`](python/Cargo.toml): the wheel (`python/pyproject.toml` reads it)
+- [`kotlin/Cargo.toml`](kotlin/Cargo.toml) and [`kotlin/android/gradle.properties`](kotlin/android/gradle.properties): the Android AAR
 
 ## License
 

--- a/kotlin/Cargo.toml
+++ b/kotlin/Cargo.toml
@@ -1,0 +1,28 @@
+# Binding crate version: bump together with the workspace release version.
+[package]
+name = "anydoc-kotlin"
+version = "0.1.9"
+edition = "2024"
+description = "Kotlin/Android bindings for anydoc"
+license = "MIT"
+repository = "https://github.com/firecrawl/anydoc"
+publish = false
+
+[lib]
+name = "anydoc_kotlin"
+crate-type = ["lib", "cdylib"]
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "uniffi-bindgen.rs"
+required-features = ["cli"]
+
+[features]
+cli = ["uniffi/cli"]
+
+[dependencies]
+anydoc = { path = ".." }
+uniffi = "0.29"
+
+[dev-dependencies]
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,0 +1,171 @@
+# anydoc for Kotlin / Android
+
+Convert Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, and PDF files
+into clean GitHub-Flavored Markdown. Kotlin bindings for the [anydoc](https://github.com/firecrawl/anydoc)
+Rust crate. The parsers stay in Rust; this package is the Android/JVM surface,
+the same role [Node](../node/README.md) and [Python](../python/README.md) play
+for those languages.
+
+The GitHub Action **Kotlin Android** (`kotlin.yml`) builds the native
+libraries, packs them into an AAR, and publishes a Maven repo. That is the
+artifact an Android app depends on.
+
+## Add it to an Android app
+
+After the workflow has published a release (tag `v0.1.9` or a manual run
+with **publish**), pick one:
+
+### GitHub Packages (recommended once published)
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/OWNER/REPO")
+            credentials {
+                username = providers.gradleProperty("gpr.user").orElse(System.getenv("GITHUB_ACTOR"))
+                password = providers.gradleProperty("gpr.key").orElse(System.getenv("GITHUB_TOKEN"))
+            }
+        }
+    }
+}
+
+// app/build.gradle.kts
+dependencies {
+    implementation("dev.firecrawl:anydoc:0.1.9")
+}
+```
+
+GitHub Packages needs a token to read, even for public repos. A fine-grained
+PAT with `read:packages` is enough. Put it in `~/.gradle/gradle.properties`
+as `gpr.user` / `gpr.key`.
+
+### AAR from the GitHub Release or workflow artifact
+
+Download `anydoc-0.1.9.aar` from the release (or the **kotlin-aar** workflow
+artifact) and drop it in `app/libs/`:
+
+```kotlin
+dependencies {
+    implementation(files("libs/anydoc-0.1.9.aar"))
+    implementation("net.java.dev.jna:jna:5.19.1@aar")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+}
+```
+
+The Maven publication already pulls JNA and coroutines transitively. The raw
+AAR does not, so add them yourself.
+
+The AAR ships `libanydoc_kotlin.so` for `arm64-v8a`, `armeabi-v7a`, and
+`x86_64`, aligned for 16 KB pages.
+
+## Usage
+
+```kotlin
+import dev.firecrawl.anydoc.Format
+import dev.firecrawl.anydoc.toDocument
+import dev.firecrawl.anydoc.toMarkdown
+import dev.firecrawl.anydoc.toMarkdownBytes
+import dev.firecrawl.anydoc.toMarkdownBytesAsync
+
+// From a file path (app-private files only):
+val markdown = toMarkdown("/data/data/app/files/report.docx")
+
+// From bytes, with the format detected from the content:
+val fromBytes = toMarkdownBytes(bytes)
+
+// Or name it, which signature-less formats (CSV) need:
+val fromCsv = toMarkdownBytes(bytes, Format.CSV)
+
+// Or stop at the document model, which also carries embedded assets:
+val document = toDocument(bytes)
+
+// Off the main thread (this is CPU work):
+val async = toMarkdownBytesAsync(bytes)
+```
+
+Android `content://` URIs are not filesystem paths. Use the Android helpers.
+They read at most `MAX_DOCUMENT_BYTES` (128 MiB) so a hostile stream cannot
+OOM the process before the Rust limits run.
+
+```kotlin
+import dev.firecrawl.anydoc.android.toMarkdown
+import dev.firecrawl.anydoc.android.toMarkdownAsync
+
+val markdown = contentResolver.toMarkdown(uri)
+val async = contentResolver.toMarkdownAsync(uri)
+```
+
+## Errors
+
+A conversion throws only when no meaningful Markdown could come out of the
+file. Each failure is a subclass of `ConvertException` (UniFFI's name for
+the Rust `ConvertError`). `error.code` is the stable name to branch on;
+`error.reason` is the full sentence.
+
+```kotlin
+try {
+    toMarkdown(path)
+} catch (error: ConvertException) {
+    if (error.code == "encrypted" || error.code == "unsupported") {
+        unconverted += path to error.code
+        return null
+    }
+    throw error
+}
+```
+
+| `code`          | Class                              | Meaning                                                             |
+| --------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| `unsupported`   | `ConvertException.Unsupported`     | Unknown format, or one that cannot be converted (an image-only PDF) |
+| `malformed`     | `ConvertException.Malformed`       | Structurally unusable: no meaningful content could be extracted     |
+| `encrypted`     | `ConvertException.Encrypted`       | Encrypted or password-protected                                     |
+| `resourceLimit` | `ConvertException.ResourceLimit`   | Crossed a fixed safety limit (decompression, nesting, node count)   |
+| `missingPart`   | `ConvertException.MissingPart`     | A part required for any meaningful output is absent                 |
+| `io`            | `ConvertException.Io`              | The file could not be read, from `toMarkdown` only                  |
+
+`Malformed.part` and `MissingPart.part` name the package part at fault.
+`ResourceLimit.limit` names the limit crossed.
+
+## Format detection
+
+```kotlin
+formatFromBytes(bytes)          // Format.DOCX, or null when nothing matches
+formatFromExtension(".pptm")    // Format.PPTX
+formatFromPath("report.odt")    // Format.ODT
+```
+
+CSV has no content signature. Detection returns `null` and the caller has to
+name `Format.CSV`.
+
+`toDocument` is unsupported for PDF: PDF conversion emits Markdown directly.
+Use `toMarkdownBytes`.
+
+## Build it yourself
+
+From the repository root:
+
+```bash
+# Host library + Kotlin sources + JVM tests (no Android SDK needed)
+cargo test -p anydoc-kotlin
+sh kotlin/scripts/generate-bindings.sh
+cd kotlin/android/jvm-test
+gradle test -Panydoc.nativeDir="$PWD/../../../target/debug"
+
+# Android .so files (needs NDK r28+ and cargo-ndk)
+cargo install cargo-ndk --locked --version 4.1.2
+rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
+sh kotlin/scripts/build-android.sh
+cd kotlin/android
+gradle :anydoc:assembleRelease :anydoc:publishReleasePublicationToLocalBuildRepository
+```
+
+The AAR lands in `kotlin/android/anydoc/build/outputs/aar/`. The local Maven
+repo lands in `kotlin/android/build/maven/`.
+
+## License
+
+[MIT](../LICENSE)

--- a/kotlin/android/.gitignore
+++ b/kotlin/android/.gitignore
@@ -1,0 +1,9 @@
+.gradle/
+build/
+local.properties
+**/jniLibs/
+generated/
+.idea/
+*.iml
+.cxx/
+captures/

--- a/kotlin/android/anydoc/build.gradle.kts
+++ b/kotlin/android/anydoc/build.gradle.kts
@@ -1,0 +1,108 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("maven-publish")
+}
+
+val groupIdValue = providers.gradleProperty("GROUP_ID").get()
+val artifactIdValue = providers.gradleProperty("ARTIFACT_ID").get()
+val versionName = providers.gradleProperty("VERSION_NAME").get()
+
+android {
+    namespace = "dev.firecrawl.anydoc"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 24
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    packaging {
+        jniLibs {
+            useLegacyPackaging = false
+        }
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
+
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDir("../generated")
+            kotlin.srcDir("../common")
+        }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    api("net.java.dev.jna:jna:5.19.1@aar")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            register<MavenPublication>("release") {
+                groupId = groupIdValue
+                artifactId = artifactIdValue
+                version = versionName
+                from(components["release"])
+                pom {
+                    name.set("anydoc")
+                    description.set(
+                        "Convert Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, and PDF files into GitHub-Flavored Markdown.",
+                    )
+                    url.set("https://github.com/firecrawl/anydoc")
+                    licenses {
+                        license {
+                            name.set("MIT License")
+                            url.set("https://opensource.org/licenses/MIT")
+                        }
+                    }
+                    scm {
+                        url.set("https://github.com/firecrawl/anydoc")
+                        connection.set("scm:git:https://github.com/firecrawl/anydoc.git")
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                name = "LocalBuild"
+                url = uri(rootProject.layout.buildDirectory.dir("maven"))
+            }
+            maven {
+                name = "GitHubPackages"
+                url = uri(
+                    "https://maven.pkg.github.com/${System.getenv("GITHUB_REPOSITORY") ?: "firecrawl/anydoc"}",
+                )
+                credentials {
+                    username = System.getenv("GITHUB_ACTOR")
+                    password = System.getenv("GITHUB_TOKEN")
+                }
+            }
+        }
+    }
+}

--- a/kotlin/android/anydoc/consumer-rules.pro
+++ b/kotlin/android/anydoc/consumer-rules.pro
@@ -1,0 +1,6 @@
+-keep class dev.firecrawl.anydoc.** { *; }
+-keep class com.sun.jna.** { *; }
+-keepclassmembers class * extends com.sun.jna.** { public *; }
+-dontwarn java.awt.*
+-dontwarn javax.swing.*
+-dontwarn com.sun.jna.platform.**

--- a/kotlin/android/anydoc/src/main/AndroidManifest.xml
+++ b/kotlin/android/anydoc/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/kotlin/android/anydoc/src/main/kotlin/dev/firecrawl/anydoc/android/Content.kt
+++ b/kotlin/android/anydoc/src/main/kotlin/dev/firecrawl/anydoc/android/Content.kt
@@ -1,0 +1,41 @@
+package dev.firecrawl.anydoc.android
+
+import android.content.ContentResolver
+import android.net.Uri
+import dev.firecrawl.anydoc.ConvertException
+import dev.firecrawl.anydoc.Document
+import dev.firecrawl.anydoc.Format
+import dev.firecrawl.anydoc.MAX_DOCUMENT_BYTES
+import dev.firecrawl.anydoc.readDocumentBytes
+import dev.firecrawl.anydoc.toDocument
+import dev.firecrawl.anydoc.toMarkdownBytes
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Read a `content://` or `file://` URI into memory, capped at
+ * [MAX_DOCUMENT_BYTES]. Android scoped storage does not give the Rust crate
+ * a usable filesystem path.
+ */
+fun ContentResolver.readDocumentBytes(
+    uri: Uri,
+    maxBytes: Int = MAX_DOCUMENT_BYTES,
+): ByteArray =
+    openInputStream(uri)?.use { it.readDocumentBytes(maxBytes) }
+        ?: throw ConvertException.Io("unable to open document")
+
+fun ContentResolver.toMarkdown(uri: Uri, format: Format? = null): String =
+    toMarkdownBytes(readDocumentBytes(uri), format)
+
+fun ContentResolver.toDocument(uri: Uri, format: Format? = null): Document =
+    toDocument(readDocumentBytes(uri), format)
+
+suspend fun ContentResolver.toMarkdownAsync(uri: Uri, format: Format? = null): String {
+    val bytes = withContext(Dispatchers.IO) { readDocumentBytes(uri) }
+    return withContext(Dispatchers.Default) { toMarkdownBytes(bytes, format) }
+}
+
+suspend fun ContentResolver.toDocumentAsync(uri: Uri, format: Format? = null): Document {
+    val bytes = withContext(Dispatchers.IO) { readDocumentBytes(uri) }
+    return withContext(Dispatchers.Default) { toDocument(bytes, format) }
+}

--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("com.android.library") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.0.21" apply false
+}

--- a/kotlin/android/common/dev/firecrawl/anydoc/Extensions.kt
+++ b/kotlin/android/common/dev/firecrawl/anydoc/Extensions.kt
@@ -1,0 +1,84 @@
+@file:JvmName("AnydocExtensions")
+
+package dev.firecrawl.anydoc
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Hard cap on a single in-memory document read (URI helper and
+ * [readDocumentBytes]). Matches anydoc's `MAX_ENTRY_BYTES` (128 MiB) so a
+ * hostile `content://` stream cannot OOM the process before Rust sees it.
+ */
+const val MAX_DOCUMENT_BYTES: Int = 128 * 1024 * 1024
+
+/**
+ * Copy [this] into a [ByteArray], refusing anything larger than [maxBytes].
+ * Throws [ConvertException.ResourceLimit] rather than growing without bound.
+ */
+fun InputStream.readDocumentBytes(maxBytes: Int = MAX_DOCUMENT_BYTES): ByteArray {
+    require(maxBytes > 0) { "maxBytes must be positive" }
+    val out = ByteArrayOutputStream()
+    val buf = ByteArray(64 * 1024)
+    var total = 0L
+    val limit = maxBytes.toLong()
+    while (true) {
+        val n = read(buf)
+        if (n < 0) break
+        total += n.toLong()
+        if (total > limit) {
+            throw ConvertException.ResourceLimit(
+                "max_input_bytes",
+                "document exceeds $maxBytes bytes",
+            )
+        }
+        out.write(buf, 0, n)
+    }
+    return out.toByteArray()
+}
+
+/**
+ * UniFFI exports the Rust `ConvertError` as [ConvertException]. `code` is
+ * the stable name callers branch on, matching Node's `error.code`.
+ */
+val ConvertException.code: String
+    get() = when (this) {
+        is ConvertException.Unsupported -> "unsupported"
+        is ConvertException.Malformed -> "malformed"
+        is ConvertException.Encrypted -> "encrypted"
+        is ConvertException.ResourceLimit -> "resourceLimit"
+        is ConvertException.MissingPart -> "missingPart"
+        is ConvertException.Io -> "io"
+    }
+
+/** Full sentence matching the Rust `Display` for this failure. */
+val ConvertException.reason: String
+    get() = when (this) {
+        is ConvertException.Unsupported -> "unsupported input: $detail"
+        is ConvertException.Malformed ->
+            if (part != null) "malformed document ($part): $detail" else "malformed document: $detail"
+        is ConvertException.Encrypted -> "document is encrypted"
+        is ConvertException.ResourceLimit -> "resource limit exceeded ($limit): $detail"
+        is ConvertException.MissingPart -> "missing required part: $part"
+        is ConvertException.Io -> "io error: $detail"
+    }
+
+/** [toMarkdown] on a background IO dispatcher. */
+suspend fun toMarkdownAsync(path: String): String =
+    withContext(Dispatchers.IO) { toMarkdown(path) }
+
+/** [toMarkdownBytes] on a background CPU dispatcher. */
+suspend fun toMarkdownBytesAsync(bytes: ByteArray, format: Format? = null): String =
+    withContext(Dispatchers.Default) { toMarkdownBytes(bytes, format) }
+
+/** Optional-format overload so callers are not forced to pass `null`. */
+fun toMarkdownBytes(bytes: ByteArray): String = toMarkdownBytes(bytes, null)
+
+/** [toDocument] on a background CPU dispatcher. */
+suspend fun toDocumentAsync(bytes: ByteArray, format: Format? = null): Document =
+    withContext(Dispatchers.Default) { toDocument(bytes, format) }
+
+/** Optional-format overload so callers are not forced to pass `null`. */
+fun toDocument(bytes: ByteArray): Document = toDocument(bytes, null)

--- a/kotlin/android/gradle.properties
+++ b/kotlin/android/gradle.properties
@@ -1,0 +1,8 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true
+
+GROUP_ID=dev.firecrawl
+ARTIFACT_ID=anydoc
+VERSION_NAME=0.1.9

--- a/kotlin/android/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/kotlin/android/jvm-test/build.gradle.kts
+++ b/kotlin/android/jvm-test/build.gradle.kts
@@ -1,0 +1,45 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.0.21"
+}
+
+val nativeDir = providers.gradleProperty("anydoc.nativeDir")
+    .orElse(providers.environmentVariable("ANYDOC_NATIVE_DIR"))
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+sourceSets {
+    main {
+        kotlin.srcDir("../generated")
+        kotlin.srcDir("../common")
+    }
+}
+
+dependencies {
+    implementation("net.java.dev.jna:jna:5.19.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+    // Resolve at execution, not configuration: this project is sometimes
+    // evaluated by a parent build that never runs these tests.
+    doFirst {
+        val dir = nativeDir.orNull
+            ?: error("Pass -Panydoc.nativeDir=... or set ANYDOC_NATIVE_DIR to the directory containing the anydoc_kotlin native library")
+        environment("ANYDOC_NATIVE_DIR", dir)
+        systemProperty("jna.library.path", dir)
+        systemProperty("uniffi.component.anydoc.libraryOverride", "anydoc_kotlin")
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}

--- a/kotlin/android/jvm-test/settings.gradle.kts
+++ b/kotlin/android/jvm-test/settings.gradle.kts
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "anydoc-jvm-test"

--- a/kotlin/android/jvm-test/src/test/kotlin/dev/firecrawl/anydoc/AnydocTest.kt
+++ b/kotlin/android/jvm-test/src/test/kotlin/dev/firecrawl/anydoc/AnydocTest.kt
@@ -1,0 +1,174 @@
+package dev.firecrawl.anydoc
+
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.readBytes
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AnydocTest {
+    private val fixtures: Path = fixtureRoot()
+
+    @Test
+    fun toMarkdownDetectsTheFormatFromTheFileContent() {
+        val markdown = toMarkdown(fixtures.resolve("docx/handmade-outline.docx").toString())
+        assertTrue(markdown.lineSequence().any { it.startsWith("# ") }, markdown)
+    }
+
+    @Test
+    fun toMarkdownBytesConvertsInMemory() {
+        val markdown = toMarkdownBytes(
+            fixtures.resolve("docx/handmade-rich.docx").readBytes(),
+            Format.DOCX,
+        )
+        assertContains(markdown, "| Quarter | Widgets |")
+    }
+
+    @Test
+    fun toMarkdownBytesDetectsTheFormatWhenNoneIsNamed() {
+        val rich = fixtures.resolve("docx/handmade-rich.docx").readBytes()
+        assertContains(toMarkdownBytes(rich), "| Quarter | Widgets |")
+
+        val csv = fixtures.resolve("csv/sheet.csv").readBytes()
+        val unsupported = assertFailsWith<ConvertException.Unsupported> { toMarkdownBytes(csv) }
+        assertContains(unsupported.detail, "unrecognized file content")
+        assertEquals("unsupported", unsupported.code)
+        assertContains(toMarkdownBytes(csv, Format.CSV), "| --- |")
+    }
+
+    @Test
+    fun toDocumentExposesTheDocumentModel() {
+        val document = toDocument(
+            fixtures.resolve("docx/handmade-outline.docx").readBytes(),
+            Format.DOCX,
+        )
+        val heading = document.blocks.filterIsInstance<Block.Heading>().first()
+        assertTrue(heading.level.toUInt() in 1u..6u)
+        val text = assertIs<Inline.Text>(heading.content.first())
+        assertTrue(text.text.isNotEmpty())
+        assertIs<Boolean>(text.style.bold)
+    }
+
+    @Test
+    fun toDocumentCarriesEmbeddedAssetsAsBytes() {
+        val document = toDocument(
+            fixtures.resolve("docx/handmade-rich.docx").readBytes(),
+            Format.DOCX,
+        )
+        val image = document.assets.first { it.mediaType == "image/png" }
+        assertTrue(image.data.isNotEmpty())
+        assertEquals(document.assets.indexOfFirst { it.id == image.id }.toUInt(), image.id)
+    }
+
+    @Test
+    fun formatDetectionReadsContentExtensionAndPath() {
+        assertEquals(
+            Format.DOCX,
+            formatFromBytes(fixtures.resolve("docx/handmade-rich.docx").readBytes()),
+        )
+        assertNull(formatFromBytes(fixtures.resolve("csv/sheet.csv").readBytes()))
+        assertEquals(Format.PPTX, formatFromExtension(".pptm"))
+        assertEquals(Format.XLSX, formatFromExtension("xls"))
+        assertEquals(Format.ODT, formatFromPath("/tmp/report.odt"))
+        assertNull(formatFromPath("/tmp/report.unknown"))
+    }
+
+    @Test
+    fun conversionErrorsNameTheFailure() {
+        val malformed = assertFailsWith<ConvertException.Malformed> {
+            toMarkdownBytes("not a document".toByteArray(), Format.DOCX)
+        }
+        assertNull(malformed.part)
+        assertEquals("malformed", malformed.code)
+
+        assertFailsWith<ConvertException.Unsupported> {
+            toMarkdownBytes(fixtures.resolve("csv/sheet.csv").readBytes())
+        }
+
+        assertFailsWith<ConvertException.Encrypted> {
+            toMarkdownBytes(
+                fixtures.resolve("malformed/encrypted--errors.odt").readBytes(),
+                Format.ODT,
+            )
+        }
+        assertFailsWith<ConvertException.Encrypted> {
+            toDocument(
+                fixtures.resolve("malformed/encrypted--errors.odt").readBytes(),
+                Format.ODT,
+            )
+        }
+
+        val limit = assertFailsWith<ConvertException.ResourceLimit> {
+            toMarkdownBytes(
+                fixtures.resolve("abuse/zipbomb--errors.docx").readBytes(),
+                Format.DOCX,
+            )
+        }
+        assertEquals("max_entry_bytes", limit.limit)
+        assertEquals("resourceLimit", limit.code)
+
+        val io = assertFailsWith<ConvertException.Io> { toMarkdown("no-such-file.docx") }
+        assertEquals("io", io.code)
+        assertContains(io.reason, "io error")
+    }
+
+    @Test
+    fun missingPartNamesThePart() {
+        val packageBytes = zipOf("[Content_Types].xml" to "<Types/>".toByteArray())
+        val missing = assertFailsWith<ConvertException.MissingPart> {
+            toMarkdownBytes(packageBytes, Format.DOCX)
+        }
+        assertEquals("word/document.xml", missing.part)
+        assertEquals("missingPart", missing.code)
+    }
+
+    @Test
+    fun streamReadStopsAtTheDocumentByteCap() {
+        val over = ByteArray(16) { 1 }
+        val limit = assertFailsWith<ConvertException.ResourceLimit> {
+            ByteArrayInputStream(over).readDocumentBytes(maxBytes = 8)
+        }
+        assertEquals("max_input_bytes", limit.limit)
+        assertEquals("resourceLimit", limit.code)
+
+        val under = byteArrayOf(1, 2, 3, 4)
+        assertEquals(
+            under.toList(),
+            ByteArrayInputStream(under).readDocumentBytes(maxBytes = 8).toList(),
+        )
+    }
+
+    private fun zipOf(vararg files: Pair<String, ByteArray>): ByteArray {
+        val out = java.io.ByteArrayOutputStream()
+        ZipOutputStream(out).use { zip ->
+            for ((name, bytes) in files) {
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(bytes)
+                zip.closeEntry()
+            }
+        }
+        return out.toByteArray()
+    }
+
+    companion object {
+        private fun fixtureRoot(): Path {
+            var dir = Path.of("").toAbsolutePath()
+            repeat(8) {
+                val candidate = dir.resolve("tests").resolve("fixtures")
+                if (Files.exists(candidate)) {
+                    return candidate
+                }
+                dir = dir.parent ?: error("could not find tests/fixtures from ${Path.of("").toAbsolutePath()}")
+            }
+            error("could not find tests/fixtures")
+        }
+    }
+}

--- a/kotlin/android/settings.gradle.kts
+++ b/kotlin/android/settings.gradle.kts
@@ -1,0 +1,20 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "anydoc-kotlin"
+include(":anydoc")
+// :jvm-test is a standalone Gradle project (its own settings.gradle.kts).
+// Including it here would configure its test task on every AAR build.

--- a/kotlin/scripts/build-android.sh
+++ b/kotlin/scripts/build-android.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Cross-compile libanydoc_kotlin.so for Android ABIs and lay them out for the AAR.
+# Requires ANDROID_NDK_HOME (or ANDROID_NDK_ROOT) and cargo-ndk.
+# Run from the repository root: sh kotlin/scripts/build-android.sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+cd "$root"
+
+if [ -z "${ANDROID_NDK_HOME:-}${ANDROID_NDK_ROOT:-}" ]; then
+  echo "error: set ANDROID_NDK_HOME to an NDK r28+ install (16 KB page size)." >&2
+  exit 1
+fi
+
+export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-$ANDROID_NDK_ROOT}"
+
+# 16 KB ELF alignment: required for Play on 64-bit Android 15+.
+export CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS="${CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS:-} -C link-arg=-Wl,-z,max-page-size=16384"
+export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUSTFLAGS="${CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUSTFLAGS:-} -C link-arg=-Wl,-z,max-page-size=16384"
+export CARGO_TARGET_X86_64_LINUX_ANDROID_RUSTFLAGS="${CARGO_TARGET_X86_64_LINUX_ANDROID_RUSTFLAGS:-} -C link-arg=-Wl,-z,max-page-size=16384"
+
+out="$root/kotlin/android/anydoc/src/main/jniLibs"
+mkdir -p "$out"
+
+cargo ndk \
+  -t arm64-v8a \
+  -t armeabi-v7a \
+  -t x86_64 \
+  --platform 24 \
+  -o "$out" \
+  build -p anydoc-kotlin --lib --release
+
+echo "Android native libraries in $out"
+found=0
+for so in "$out"/*/libanydoc_kotlin.so; do
+  [ -f "$so" ] || continue
+  found=1
+  echo "$so"
+  python3 - "$so" <<'PY'
+import struct, sys
+path = sys.argv[1]
+data = open(path, "rb").read()
+if data[:4] != b"\x7fELF":
+    sys.exit(f"{path}: not ELF")
+ei_class = data[4]
+if ei_class == 2:
+    e_phoff = struct.unpack_from("<Q", data, 32)[0]
+    e_phentsize, e_phnum = struct.unpack_from("<HH", data, 54)
+    p_align_off = 48
+    p_align_fmt = "<Q"
+elif ei_class == 1:
+    e_phoff = struct.unpack_from("<I", data, 28)[0]
+    e_phentsize, e_phnum = struct.unpack_from("<HH", data, 42)
+    p_align_off = 28
+    p_align_fmt = "<I"
+else:
+    sys.exit(f"{path}: unknown ELF class {ei_class}")
+align = 0
+off = e_phoff
+for _ in range(e_phnum):
+    p_type = struct.unpack_from("<I", data, off)[0]
+    if p_type == 1:  # PT_LOAD
+        align = max(align, struct.unpack_from(p_align_fmt, data, off + p_align_off)[0])
+    off += e_phentsize
+if align < 16384:
+    sys.exit(f"{path}: PT_LOAD align {align} < 16384 (16 KB page size)")
+print(f"{path}: PT_LOAD align {align}")
+PY
+done
+if [ "$found" -eq 0 ]; then
+  echo "error: no libanydoc_kotlin.so produced" >&2
+  exit 1
+fi

--- a/kotlin/scripts/generate-bindings.sh
+++ b/kotlin/scripts/generate-bindings.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the host cdylib and generate Kotlin bindings from it.
+# Run from the repository root: sh kotlin/scripts/generate-bindings.sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+cd "$root"
+
+profile=${ANYDOC_PROFILE:-debug}
+if [ "$profile" = release ]; then
+  cargo build -p anydoc-kotlin --lib --release
+else
+  cargo build -p anydoc-kotlin --lib
+fi
+
+lib=""
+for candidate in \
+  "target/$profile/libanydoc_kotlin.so" \
+  "target/$profile/libanydoc_kotlin.dylib" \
+  "target/$profile/anydoc_kotlin.dll"
+do
+  if [ -f "$candidate" ]; then
+    lib=$candidate
+    break
+  fi
+done
+
+if [ -z "$lib" ]; then
+  echo "error: anydoc_kotlin native library not found under target/$profile" >&2
+  exit 1
+fi
+
+out="$root/kotlin/android/generated"
+mkdir -p "$out"
+cargo run -p anydoc-kotlin --features cli --bin uniffi-bindgen -- \
+  generate --library "$lib" --language kotlin --out-dir "$out"
+
+echo "generated Kotlin bindings in $out from $lib"
+echo "native dir: $root/target/$profile"

--- a/kotlin/src/document.rs
+++ b/kotlin/src/document.rs
@@ -1,0 +1,358 @@
+//! The document model, mapped onto UniFFI types.
+//!
+//! Recursive ADTs (`Block`, `Inline`) stay enums so Kotlin gets sealed
+//! classes. `List` is exported as `DocList` to avoid colliding with
+//! `kotlin.collections.List`.
+
+use anydoc::model;
+
+/// A parsed document: its body, its notes, and the bytes of everything it
+/// embedded.
+#[derive(Debug, uniffi::Record)]
+pub struct Document {
+    pub blocks: Vec<Block>,
+    /// Footnote and endnote bodies, referenced from text by a `note_ref`
+    /// inline.
+    pub notes: Vec<Note>,
+    pub assets: Vec<Asset>,
+}
+
+/// One block-level piece of a document body.
+#[derive(Debug, uniffi::Enum)]
+pub enum Block {
+    Heading {
+        level: u8,
+        anchor: Option<String>,
+        content: Vec<Inline>,
+    },
+    Paragraph {
+        content: Vec<Inline>,
+    },
+    /// Named `ListBlock` so Kotlin does not shadow `kotlin.collections.List`.
+    ListBlock {
+        list: DocList,
+    },
+    /// Named `TableBlock` so it does not shadow the `Table` record type.
+    TableBlock {
+        table: Table,
+    },
+    BlockQuote {
+        blocks: Vec<Block>,
+    },
+    CodeBlock {
+        lang: Option<String>,
+        text: String,
+    },
+    Rule,
+}
+
+/// One span of inline content.
+#[derive(Debug, uniffi::Enum)]
+pub enum Inline {
+    Text {
+        text: String,
+        style: Style,
+    },
+    Link {
+        content: Vec<Inline>,
+        target: LinkTarget,
+    },
+    Image {
+        alt: String,
+        source: ImageSource,
+    },
+    /// Zero-width marker for an internal link target at this position.
+    Anchor {
+        anchor: String,
+    },
+    NoteRef {
+        note_id: String,
+    },
+    LineBreak,
+}
+
+/// Fully resolved character style.
+#[derive(Debug, uniffi::Record)]
+pub struct Style {
+    pub bold: bool,
+    pub italic: bool,
+    pub strike: bool,
+    pub code: bool,
+}
+
+/// Where a link points.
+#[derive(Debug, uniffi::Enum)]
+pub enum LinkTarget {
+    /// Absolute URL with a scheme.
+    External { value: String },
+    /// Scheme-less relative reference, preserved as written.
+    Relative { value: String },
+    /// Internal target: a heading anchor or an `anchor` inline.
+    Anchor { value: String },
+}
+
+/// Where an image's bytes live.
+#[derive(Debug, uniffi::Enum)]
+pub enum ImageSource {
+    External { url: String },
+    Asset { asset_id: u32 },
+    Unavailable,
+}
+
+/// The marker family a list uses in the source document.
+#[derive(Debug, uniffi::Enum)]
+pub enum MarkerKind {
+    Bullet,
+    Decimal,
+    LowerAlpha,
+    UpperAlpha,
+    LowerRoman,
+    UpperRoman,
+}
+
+/// A fully resolved list. Named `DocList` in Kotlin so it does not shadow
+/// `kotlin.collections.List`.
+#[derive(Debug, uniffi::Record)]
+pub struct DocList {
+    pub marker: MarkerKind,
+    /// Ordinal of the first item, from the source's own numbering.
+    pub start: u64,
+    pub items: Vec<ListItem>,
+}
+
+/// One item of a [`DocList`], which may hold nested blocks including further
+/// lists.
+#[derive(Debug, uniffi::Record)]
+pub struct ListItem {
+    pub blocks: Vec<Block>,
+    /// Checkbox state for a task list item; `None` when the item carries no
+    /// checkbox.
+    pub checked: Option<bool>,
+    /// Literal marker text that overrides the level marker when the source
+    /// number text cannot be reproduced from `marker` + position alone.
+    pub marker_label: Option<String>,
+}
+
+/// What a table is for.
+#[derive(Debug, uniffi::Enum)]
+pub enum TableKind {
+    Data,
+    Layout,
+}
+
+/// Canonical table grid: every logical grid position appears exactly once.
+#[derive(Debug, uniffi::Record)]
+pub struct Table {
+    pub grid: Vec<Vec<CellSlot>>,
+    /// Number of leading rows that are header rows (0 = no header).
+    pub header_rows: u32,
+    pub kind: TableKind,
+}
+
+/// One position in a [`Table`] grid: either a cell or the shadow of one.
+#[derive(Debug, uniffi::Enum)]
+pub enum CellSlot {
+    Origin { cell: Cell },
+    Covered { origin_row: u32, origin_col: u32 },
+}
+
+/// A table cell and the extent it spans.
+#[derive(Debug, uniffi::Record)]
+pub struct Cell {
+    pub blocks: Vec<Block>,
+    pub col_span: u32,
+    pub row_span: u32,
+}
+
+/// Footnote or endnote body, referenced from text by [`Inline::NoteRef`].
+#[derive(Debug, uniffi::Record)]
+pub struct Note {
+    pub id: String,
+    pub kind: NoteKind,
+    pub blocks: Vec<Block>,
+}
+
+/// Where the source document places a note.
+#[derive(Debug, uniffi::Enum)]
+pub enum NoteKind {
+    Footnote,
+    Endnote,
+}
+
+/// An embedded binary asset (image, object payload).
+#[derive(Debug, uniffi::Record)]
+pub struct Asset {
+    /// Index into `Document.assets`, as referenced by an image source.
+    pub id: u32,
+    /// MIME type, e.g. `image/png`.
+    pub media_type: String,
+    /// Package part or stream the asset came from, for provenance.
+    pub origin_part: String,
+    pub data: Vec<u8>,
+}
+
+impl From<model::Document> for Document {
+    fn from(document: model::Document) -> Self {
+        Document {
+            blocks: blocks(document.blocks),
+            notes: document.notes.into_iter().map(Note::from).collect(),
+            assets: document.assets.into_iter().map(Asset::from).collect(),
+        }
+    }
+}
+
+impl From<model::Block> for Block {
+    fn from(block: model::Block) -> Self {
+        match block {
+            model::Block::Heading { level, anchor, content } => {
+                Block::Heading { level, anchor, content: inlines(content) }
+            }
+            model::Block::Paragraph(content) => Block::Paragraph { content: inlines(content) },
+            model::Block::List(list) => Block::ListBlock { list: list.into() },
+            model::Block::Table(table) => Block::TableBlock { table: table.into() },
+            model::Block::BlockQuote(inner) => Block::BlockQuote { blocks: blocks(inner) },
+            model::Block::CodeBlock { lang, text } => Block::CodeBlock { lang, text },
+            model::Block::Rule => Block::Rule,
+        }
+    }
+}
+
+impl From<model::Inline> for Inline {
+    fn from(inline: model::Inline) -> Self {
+        match inline {
+            model::Inline::Text { text, style } => Inline::Text { text, style: style.into() },
+            model::Inline::Link { content, target } => {
+                Inline::Link { content: inlines(content), target: target.into() }
+            }
+            model::Inline::Image { alt, source } => Inline::Image { alt, source: source.into() },
+            model::Inline::Anchor(anchor) => Inline::Anchor { anchor },
+            model::Inline::NoteRef(note_id) => Inline::NoteRef { note_id },
+            model::Inline::LineBreak => Inline::LineBreak,
+        }
+    }
+}
+
+impl From<model::Style> for Style {
+    fn from(style: model::Style) -> Self {
+        Style { bold: style.bold, italic: style.italic, strike: style.strike, code: style.code }
+    }
+}
+
+impl From<model::LinkTarget> for LinkTarget {
+    fn from(target: model::LinkTarget) -> Self {
+        match target {
+            model::LinkTarget::External(value) => LinkTarget::External { value },
+            model::LinkTarget::Relative(value) => LinkTarget::Relative { value },
+            model::LinkTarget::Anchor(value) => LinkTarget::Anchor { value },
+        }
+    }
+}
+
+impl From<model::ImageSource> for ImageSource {
+    fn from(source: model::ImageSource) -> Self {
+        match source {
+            model::ImageSource::External(url) => ImageSource::External { url },
+            model::ImageSource::Asset(id) => ImageSource::Asset { asset_id: id.0 as u32 },
+            model::ImageSource::Unavailable => ImageSource::Unavailable,
+        }
+    }
+}
+
+impl From<model::MarkerKind> for MarkerKind {
+    fn from(marker: model::MarkerKind) -> Self {
+        match marker {
+            model::MarkerKind::Bullet => MarkerKind::Bullet,
+            model::MarkerKind::Decimal => MarkerKind::Decimal,
+            model::MarkerKind::LowerAlpha => MarkerKind::LowerAlpha,
+            model::MarkerKind::UpperAlpha => MarkerKind::UpperAlpha,
+            model::MarkerKind::LowerRoman => MarkerKind::LowerRoman,
+            model::MarkerKind::UpperRoman => MarkerKind::UpperRoman,
+        }
+    }
+}
+
+impl From<model::List> for DocList {
+    fn from(list: model::List) -> Self {
+        DocList {
+            marker: list.marker.into(),
+            start: list.start,
+            items: list.items.into_iter().map(ListItem::from).collect(),
+        }
+    }
+}
+
+impl From<model::ListItem> for ListItem {
+    fn from(item: model::ListItem) -> Self {
+        ListItem {
+            blocks: blocks(item.blocks),
+            checked: item.checked,
+            marker_label: item.marker_label,
+        }
+    }
+}
+
+impl From<model::Table> for Table {
+    fn from(table: model::Table) -> Self {
+        Table {
+            grid: table
+                .grid
+                .into_iter()
+                .map(|row| row.into_iter().map(CellSlot::from).collect())
+                .collect(),
+            header_rows: table.header_rows as u32,
+            kind: match table.kind {
+                model::TableKind::Data => TableKind::Data,
+                model::TableKind::Layout => TableKind::Layout,
+            },
+        }
+    }
+}
+
+impl From<model::CellSlot> for CellSlot {
+    fn from(slot: model::CellSlot) -> Self {
+        match slot {
+            model::CellSlot::Origin(cell) => CellSlot::Origin { cell: cell.into() },
+            model::CellSlot::Covered { origin_row, origin_col } => {
+                CellSlot::Covered { origin_row: origin_row as u32, origin_col: origin_col as u32 }
+            }
+        }
+    }
+}
+
+impl From<model::Cell> for Cell {
+    fn from(cell: model::Cell) -> Self {
+        Cell { blocks: blocks(cell.blocks), col_span: cell.col_span, row_span: cell.row_span }
+    }
+}
+
+impl From<model::Note> for Note {
+    fn from(note: model::Note) -> Self {
+        Note {
+            id: note.id,
+            kind: match note.kind {
+                model::NoteKind::Footnote => NoteKind::Footnote,
+                model::NoteKind::Endnote => NoteKind::Endnote,
+            },
+            blocks: blocks(note.blocks),
+        }
+    }
+}
+
+impl From<model::Asset> for Asset {
+    fn from(asset: model::Asset) -> Self {
+        Asset {
+            id: asset.id.0 as u32,
+            media_type: asset.media_type,
+            origin_part: asset.origin_part,
+            data: asset.bytes,
+        }
+    }
+}
+
+fn blocks(blocks: Vec<model::Block>) -> Vec<Block> {
+    blocks.into_iter().map(Block::from).collect()
+}
+
+fn inlines(inlines: Vec<model::Inline>) -> Vec<Inline> {
+    inlines.into_iter().map(Inline::from).collect()
+}

--- a/kotlin/src/lib.rs
+++ b/kotlin/src/lib.rs
@@ -1,0 +1,321 @@
+//! Kotlin/Android bindings for anydoc.
+//!
+//! Mirrors the Rust, Node, and Python APIs. Conversion stays in the
+//! `anydoc` crate; this crate only maps types across UniFFI.
+
+use std::fmt;
+use std::path::Path;
+
+uniffi::setup_scaffolding!("anydoc");
+
+mod document;
+
+pub use document::*;
+
+/// Input format, named after the extension that identifies it. Container
+/// variants that share a parser (`.docm`, `.xlsm`, `.ppsx`, ...) map onto
+/// these.
+#[derive(Clone, Copy, uniffi::Enum)]
+pub enum Format {
+    Doc,
+    Docx,
+    Odt,
+    /// Converted with pdf-inspector, which emits Markdown directly:
+    /// `to_document` is unsupported for PDFs. Scanned or image-only PDFs
+    /// (needing OCR) error as unsupported.
+    Pdf,
+    Ppt,
+    Pptx,
+    Rtf,
+    Epub,
+    Xlsx,
+    Ods,
+    Odp,
+    Csv,
+}
+
+impl From<Format> for anydoc::Format {
+    fn from(format: Format) -> Self {
+        match format {
+            Format::Doc => anydoc::Format::Doc,
+            Format::Docx => anydoc::Format::Docx,
+            Format::Odt => anydoc::Format::Odt,
+            Format::Pdf => anydoc::Format::Pdf,
+            Format::Ppt => anydoc::Format::Ppt,
+            Format::Pptx => anydoc::Format::Pptx,
+            Format::Rtf => anydoc::Format::Rtf,
+            Format::Epub => anydoc::Format::Epub,
+            Format::Xlsx => anydoc::Format::Excel,
+            Format::Ods => anydoc::Format::Ods,
+            Format::Odp => anydoc::Format::Odp,
+            Format::Csv => anydoc::Format::Csv,
+        }
+    }
+}
+
+impl From<anydoc::Format> for Format {
+    fn from(format: anydoc::Format) -> Self {
+        match format {
+            anydoc::Format::Doc => Format::Doc,
+            anydoc::Format::Docx => Format::Docx,
+            anydoc::Format::Odt => Format::Odt,
+            anydoc::Format::Pdf => Format::Pdf,
+            anydoc::Format::Ppt => Format::Ppt,
+            anydoc::Format::Pptx => Format::Pptx,
+            anydoc::Format::Rtf => Format::Rtf,
+            anydoc::Format::Epub => Format::Epub,
+            anydoc::Format::Excel => Format::Xlsx,
+            anydoc::Format::Ods => Format::Ods,
+            anydoc::Format::Odp => Format::Odp,
+            anydoc::Format::Csv => Format::Csv,
+        }
+    }
+}
+
+/// Why a conversion could not produce a useful result. Each variant is a
+/// Kotlin exception subclass; `code` on the handwritten Kotlin extension
+/// is the stable name callers branch on.
+#[derive(Debug, uniffi::Error)]
+pub enum ConvertError {
+    Unsupported { detail: String },
+    Malformed { part: Option<String>, detail: String },
+    Encrypted,
+    ResourceLimit { limit: String, detail: String },
+    MissingPart { part: String },
+    Io { detail: String },
+}
+
+impl fmt::Display for ConvertError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConvertError::Unsupported { detail } => write!(f, "unsupported input: {detail}"),
+            ConvertError::Malformed { part: Some(part), detail } => {
+                write!(f, "malformed document ({part}): {detail}")
+            }
+            ConvertError::Malformed { part: None, detail } => {
+                write!(f, "malformed document: {detail}")
+            }
+            ConvertError::Encrypted => write!(f, "document is encrypted"),
+            ConvertError::ResourceLimit { limit, detail } => {
+                write!(f, "resource limit exceeded ({limit}): {detail}")
+            }
+            ConvertError::MissingPart { part } => write!(f, "missing required part: {part}"),
+            ConvertError::Io { detail } => write!(f, "io error: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for ConvertError {}
+
+impl From<anydoc::ConvertError> for ConvertError {
+    fn from(error: anydoc::ConvertError) -> Self {
+        match error {
+            anydoc::ConvertError::Unsupported(detail) => ConvertError::Unsupported { detail },
+            anydoc::ConvertError::Malformed { part, detail } => {
+                ConvertError::Malformed { part, detail }
+            }
+            anydoc::ConvertError::Encrypted => ConvertError::Encrypted,
+            anydoc::ConvertError::ResourceLimit { limit, detail } => {
+                ConvertError::ResourceLimit { limit: limit.to_string(), detail }
+            }
+            anydoc::ConvertError::MissingPart { part } => ConvertError::MissingPart { part },
+            anydoc::ConvertError::Io(error) => ConvertError::Io { detail: error.to_string() },
+            other => ConvertError::Unsupported { detail: other.to_string() },
+        }
+    }
+}
+
+/// Detect the format from the content itself: the signature and identity each
+/// container specification designates (PDF header, RTF open group, OLE stream
+/// names, ZIP package mimetype/content types). Plain-text formats (CSV) carry
+/// no signature and return `null`; so does anything unrecognized.
+#[uniffi::export]
+pub fn format_from_bytes(bytes: Vec<u8>) -> Option<Format> {
+    anydoc::Format::from_bytes(&bytes).map(Format::from)
+}
+
+/// The format an extension names, with or without a leading dot.
+#[uniffi::export]
+pub fn format_from_extension(extension: String) -> Option<Format> {
+    anydoc::Format::from_extension(extension.trim_start_matches('.')).map(Format::from)
+}
+
+/// The format a path's (or file name's) extension names.
+#[uniffi::export]
+pub fn format_from_path(path: String) -> Option<Format> {
+    anydoc::Format::from_path(Path::new(&path)).map(Format::from)
+}
+
+/// Convert a document file to Markdown. The format is detected from the file
+/// content; the extension is the fallback for signature-less formats (CSV)
+/// and unrecognizable containers.
+#[uniffi::export]
+pub fn to_markdown(path: String) -> Result<String, ConvertError> {
+    anydoc::to_markdown(&path).map_err(ConvertError::from)
+}
+
+/// Convert an in-memory document to Markdown. Without a format, it is
+/// detected from the content, which signature-less formats (CSV) have to name
+/// explicitly.
+#[uniffi::export]
+pub fn to_markdown_bytes(bytes: Vec<u8>, format: Option<Format>) -> Result<String, ConvertError> {
+    anydoc::to_markdown_bytes(&bytes, format.map(anydoc::Format::from)).map_err(ConvertError::from)
+}
+
+/// Parse an in-memory document into the document model, which also carries
+/// the embedded assets. Without a format, it is detected from the content.
+///
+/// Unsupported for `pdf`: PDF conversion produces Markdown directly and has
+/// no document-model form; use `to_markdown_bytes`.
+#[uniffi::export]
+pub fn to_document(bytes: Vec<u8>, format: Option<Format>) -> Result<Document, ConvertError> {
+    anydoc::to_document(&bytes, format.map(anydoc::Format::from))
+        .map(Document::from)
+        .map_err(ConvertError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("tests")
+            .join("fixtures")
+            .join(name)
+    }
+
+    fn read_fixture(name: &str) -> Vec<u8> {
+        std::fs::read(fixture(name))
+            .unwrap_or_else(|e| panic!("read {}: {e}", fixture(name).display()))
+    }
+
+    #[test]
+    fn to_markdown_detects_the_format_from_the_file_content() {
+        let markdown =
+            to_markdown(fixture("docx/handmade-outline.docx").to_string_lossy().into_owned())
+                .unwrap();
+        assert!(markdown.lines().any(|line| line.starts_with("# ")), "{markdown}");
+    }
+
+    #[test]
+    fn to_markdown_bytes_converts_in_memory() {
+        let markdown =
+            to_markdown_bytes(read_fixture("docx/handmade-rich.docx"), Some(Format::Docx)).unwrap();
+        assert!(markdown.contains("| Quarter | Widgets |"), "{markdown}");
+    }
+
+    #[test]
+    fn to_markdown_bytes_detects_the_format_when_none_is_named() {
+        let markdown = to_markdown_bytes(read_fixture("docx/handmade-rich.docx"), None).unwrap();
+        assert!(markdown.contains("| Quarter | Widgets |"), "{markdown}");
+        let csv = read_fixture("csv/sheet.csv");
+        match to_markdown_bytes(csv.clone(), None) {
+            Err(ConvertError::Unsupported { detail }) => {
+                assert!(detail.contains("unrecognized file content"), "{detail}");
+            }
+            other => panic!("expected unsupported, got {other:?}"),
+        }
+        let named = to_markdown_bytes(csv, Some(Format::Csv)).unwrap();
+        assert!(named.contains("| --- |"), "{named}");
+    }
+
+    #[test]
+    fn to_document_exposes_the_document_model() {
+        let document =
+            to_document(read_fixture("docx/handmade-outline.docx"), Some(Format::Docx)).unwrap();
+        let heading = document
+            .blocks
+            .iter()
+            .find_map(|block| match block {
+                Block::Heading { level, content, .. } => Some((*level, content)),
+                _ => None,
+            })
+            .expect("outline fixture has a heading");
+        assert!((1..=6).contains(&heading.0));
+        match heading.1.first() {
+            Some(Inline::Text { text, style }) => {
+                assert!(!text.is_empty());
+                let _ = style.bold;
+            }
+            other => panic!("expected text inline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_document_carries_embedded_assets_as_bytes() {
+        let document =
+            to_document(read_fixture("docx/handmade-rich.docx"), Some(Format::Docx)).unwrap();
+        let image = document
+            .assets
+            .iter()
+            .find(|asset| asset.media_type == "image/png")
+            .expect("png asset");
+        assert!(!image.data.is_empty());
+        assert_eq!(
+            image.id as usize,
+            document.assets.iter().position(|a| a.id == image.id).unwrap()
+        );
+    }
+
+    #[test]
+    fn format_detection_reads_content_extension_and_path() {
+        assert!(matches!(
+            format_from_bytes(read_fixture("docx/handmade-rich.docx")),
+            Some(Format::Docx)
+        ));
+        assert!(format_from_bytes(read_fixture("csv/sheet.csv")).is_none());
+        assert!(matches!(format_from_extension(".pptm".into()), Some(Format::Pptx)));
+        assert!(matches!(format_from_extension("xls".into()), Some(Format::Xlsx)));
+        assert!(matches!(format_from_path("/tmp/report.odt".into()), Some(Format::Odt)));
+        assert!(format_from_path("/tmp/report.unknown".into()).is_none());
+    }
+
+    #[test]
+    fn conversion_errors_name_the_failure() {
+        match to_markdown_bytes(b"not a document".to_vec(), Some(Format::Docx)) {
+            Err(ConvertError::Malformed { part, .. }) => assert!(part.is_none()),
+            other => panic!("expected malformed, got {other:?}"),
+        }
+        match to_markdown_bytes(read_fixture("csv/sheet.csv"), None) {
+            Err(ConvertError::Unsupported { .. }) => {}
+            other => panic!("expected unsupported, got {other:?}"),
+        }
+        match to_markdown_bytes(read_fixture("malformed/encrypted--errors.odt"), Some(Format::Odt))
+        {
+            Err(ConvertError::Encrypted) => {}
+            other => panic!("expected encrypted, got {other:?}"),
+        }
+        match to_document(read_fixture("malformed/encrypted--errors.odt"), Some(Format::Odt)) {
+            Err(ConvertError::Encrypted) => {}
+            other => panic!("expected encrypted, got {other:?}"),
+        }
+        match to_markdown_bytes(read_fixture("abuse/zipbomb--errors.docx"), Some(Format::Docx)) {
+            Err(ConvertError::ResourceLimit { limit, .. }) => assert_eq!(limit, "max_entry_bytes"),
+            other => panic!("expected resource limit, got {other:?}"),
+        }
+        match to_markdown("no-such-file.docx".into()) {
+            Err(ConvertError::Io { detail }) => assert!(!detail.is_empty()),
+            other => panic!("expected io, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_part_names_the_part() {
+        let mut package = Vec::new();
+        {
+            let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut package));
+            zip.start_file("[Content_Types].xml", zip::write::SimpleFileOptions::default())
+                .unwrap();
+            zip.write_all(b"<Types/>").unwrap();
+            zip.finish().unwrap();
+        }
+        match to_markdown_bytes(package, Some(Format::Docx)) {
+            Err(ConvertError::MissingPart { part }) => assert_eq!(part, "word/document.xml"),
+            other => panic!("expected missing part, got {other:?}"),
+        }
+    }
+}

--- a/kotlin/uniffi-bindgen.rs
+++ b/kotlin/uniffi-bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/kotlin/uniffi.toml
+++ b/kotlin/uniffi.toml
@@ -1,0 +1,5 @@
+[bindings.kotlin]
+package_name = "dev.firecrawl.anydoc"
+cdylib_name = "anydoc_kotlin"
+generate_immutable_records = true
+android = false

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
-# Verify that the release version agrees across the five places it is declared:
-#   1. Cargo.toml             [package].version
-#   2. python/Cargo.toml      [package].version
-#   3. wasm/Cargo.toml        [package].version (wasm-pack stamps it on @firecrawl/anydoc-wasm)
-#   4. node/package.json      .version
-#   5. node/index.js          generated version guard (contains `!== '<version>'`)
+# Verify that the release version agrees across the places it is declared:
+#   1. Cargo.toml                       [package].version
+#   2. python/Cargo.toml                [package].version
+#   3. wasm/Cargo.toml                  [package].version (wasm-pack stamps it on @firecrawl/anydoc-wasm)
+#   4. kotlin/Cargo.toml                [package].version
+#   5. kotlin/android/gradle.properties VERSION_NAME
+#   6. node/package.json                .version
+#   7. node/index.js                    generated version guard (contains `!== '<version>'`)
 #
 # Usage (from the repo root):
 #   sh scripts/check-versions.sh          # check agreement only
@@ -18,7 +20,7 @@ err=0
 
 report() { printf '%s\n' "$*" >&2; }
 
-for f in Cargo.toml python/Cargo.toml wasm/Cargo.toml node/package.json node/index.js; do
+for f in Cargo.toml python/Cargo.toml wasm/Cargo.toml kotlin/Cargo.toml kotlin/android/gradle.properties node/package.json node/index.js; do
   if [ ! -f "$f" ]; then
     report "error: $f not found - run this script from the repository root."
     exit 1
@@ -37,6 +39,8 @@ toml_version() {
 cargo_version=$(toml_version Cargo.toml)
 python_version=$(toml_version python/Cargo.toml)
 wasm_version=$(toml_version wasm/Cargo.toml)
+kotlin_version=$(toml_version kotlin/Cargo.toml)
+gradle_version=$(sed -n 's/^VERSION_NAME=//p' kotlin/android/gradle.properties | head -n 1)
 
 # npm keeps top-level "version" as the first version key in package.json.
 package_json_version=$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' node/package.json | head -n 1)
@@ -48,6 +52,8 @@ guard_version=$(grep -o "!== '[^']*'" node/index.js | head -n 1 | sed "s/^!== '/
 [ -n "$cargo_version" ]        || { report "error: could not read [package].version from Cargo.toml"; err=1; }
 [ -n "$python_version" ]       || { report "error: could not read [package].version from python/Cargo.toml"; err=1; }
 [ -n "$wasm_version" ]         || { report "error: could not read [package].version from wasm/Cargo.toml"; err=1; }
+[ -n "$kotlin_version" ]       || { report "error: could not read [package].version from kotlin/Cargo.toml"; err=1; }
+[ -n "$gradle_version" ]       || { report "error: could not read VERSION_NAME from kotlin/android/gradle.properties"; err=1; }
 [ -n "$package_json_version" ] || { report "error: could not read .version from node/package.json"; err=1; }
 [ -n "$guard_version" ]        || { report "error: could not find the version guard (!== '<version>') in node/index.js - regenerate it with 'npm run build' in node/"; err=1; }
 
@@ -55,17 +61,21 @@ guard_version=$(grep -o "!== '[^']*'" node/index.js | head -n 1 | sed "s/^!== '/
 
 if [ "$python_version" != "$cargo_version" ] || \
    [ "$wasm_version" != "$cargo_version" ] || \
+   [ "$kotlin_version" != "$cargo_version" ] || \
+   [ "$gradle_version" != "$cargo_version" ] || \
    [ "$package_json_version" != "$cargo_version" ] || \
    [ "$guard_version" != "$cargo_version" ]; then
   report "error: the release version locations disagree:"
-  report "  Cargo.toml [package].version        = $cargo_version"
-  report "  python/Cargo.toml [package].version = $python_version"
-  report "  wasm/Cargo.toml [package].version   = $wasm_version"
-  report "  node/package.json .version          = $package_json_version"
-  report "  node/index.js version guard         = $guard_version"
-  report "fix: set all five to the same version. Bump the three Cargo.toml files"
-  report "     and node/package.json, then run 'npm run build' in node/ to"
-  report "     regenerate node/index.js, and commit the result."
+  report "  Cargo.toml [package].version                 = $cargo_version"
+  report "  python/Cargo.toml [package].version          = $python_version"
+  report "  wasm/Cargo.toml [package].version            = $wasm_version"
+  report "  kotlin/Cargo.toml [package].version          = $kotlin_version"
+  report "  kotlin/android/gradle.properties VERSION_NAME = $gradle_version"
+  report "  node/package.json .version                   = $package_json_version"
+  report "  node/index.js version guard                  = $guard_version"
+  report "fix: set every location to the same version. Bump the Cargo.toml files,"
+  report "     kotlin/android/gradle.properties, and node/package.json, then run"
+  report "     'npm run build' in node/ to regenerate node/index.js, and commit."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add a UniFFI Kotlin binding crate that exposes the same conversion API as Node and Python (`toMarkdown`, `toMarkdownBytes`, `toDocument`, format detection, typed `ConvertException`).
- Ship an Android library (`dev.firecrawl:anydoc`) with 16 KB-aligned `.so` files for `arm64-v8a`, `armeabi-v7a`, and `x86_64`, plus URI helpers that cap reads at 128 MiB.
- Add the **Kotlin Android** workflow to build the AAR, run host/JVM tests, and publish to GitHub Packages on a `v*` tag (or a manual run with publish).

## How to use
After the workflow publishes:
```kotlin
implementation("dev.firecrawl:anydoc:0.1.9")
```
See `kotlin/README.md` for AAR-from-release install and the Android `ContentResolver` helpers.

## Test plan
- [x] `cargo test -p anydoc-kotlin` (8 Rust binding tests)
- [x] `cargo clippy -p anydoc-kotlin --all-targets -- -D warnings`
- [x] JVM suite in `kotlin/android/jvm-test` (9 tests, including zipbomb, encrypted, missing part, and the 128 MiB stream cap)
- [ ] GitHub Action **Kotlin Android** on this PR / after merge (cross-compiles Android `.so` and assembles the AAR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kotlin/Android bindings and an AAR so Android and JVM apps can use the same conversion API. It also adds CI to build/test/publish the AAR and enforces 16 KB ELF alignment for Android 15+ Play compliance.

- Introduces `anydoc-kotlin` (UniFFI) exposing `toMarkdown`, `toMarkdownBytes`, `toDocument`, format detection, and typed `ConvertException`. PDF still converts to Markdown only (no `toDocument`).
- Ships Android AAR `dev.firecrawl:anydoc` with `.so` for `arm64-v8a`, `armeabi-v7a`, and `x86_64`, plus `ContentResolver` helpers that cap reads at 128 MiB. `.cargo/config.toml` sets `-z,max-page-size=16384` for Android targets.
- Adds the `Kotlin Android` workflow to run Rust/JVM tests, cross-compile the `.so` files (NDK r28c), assemble the AAR, upload artifacts, and on `v*` tags publish to GitHub Packages and attach artifacts to the GitHub Release. `ci.yml` also runs host/JVM binding tests.
- Updates `README.md` and release tooling. `scripts/check-versions.sh` now validates `kotlin/Cargo.toml` and `kotlin/android/gradle.properties`. When releasing, bump those along with existing version files.

<sup>Written for commit 20ecb57816e6146a62110483a2294667b972cccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

