### PR TITLE
fix: escape code span pipes in table cells

### DIFF
--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -205,7 +205,11 @@ fn render_text_run(
     }
     if !core.is_empty() {
         if style.code {
-            push_code_span(core, out);
+            if ctx == InlineContext::TableCell {
+                push_table_cell_code_span(core, out);
+            } else {
+                push_code_span(core, out);
+            }
         } else {
             let mut open = String::new();
             if style.strike {
@@ -233,7 +237,16 @@ fn render_text_run(
 }
 
 pub(crate) fn push_code_span(text: &str, out: &mut String) {
+    push_code_span_inner(text, false, out);
+}
+
+pub(crate) fn push_table_cell_code_span(text: &str, out: &mut String) {
+    push_code_span_inner(text, true, out);
+}
+
+fn push_code_span_inner(text: &str, escape_table_pipes: bool, out: &mut String) {
     let text = text.replace('\n', " ");
+    let text = if escape_table_pipes { text.replace('|', "\\|") } else { text };
     let fence = backtick_fence(&text, 1);
     let pad = if text.starts_with('`') || text.ends_with('`') { " " } else { "" };
     let _ = write!(out, "{fence}{pad}{text}{pad}{fence}");

--- a/src/render/markdown/table.rs
+++ b/src/render/markdown/table.rs
@@ -166,7 +166,7 @@ fn cell_block_text(block: &Block, rc: &Ctx, parts: &mut Vec<String>) {
             let t = text.trim();
             if !t.is_empty() {
                 let mut s = String::new();
-                crate::render::markdown::inline::push_code_span(t, &mut s);
+                crate::render::markdown::inline::push_table_cell_code_span(t, &mut s);
                 parts.push(s);
             }
         }

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -296,6 +296,23 @@ fn url_pipes_cannot_split_table_cells() {
 }
 
 #[test]
+fn code_span_pipes_cannot_split_table_cells() {
+    let cell =
+        Cell::from_inlines(vec![styled("left | right", Style { code: true, ..Style::PLAIN })]);
+    let md =
+        doc(vec![table_from(vec![vec![cell, Cell::from_inlines(vec![Inline::plain("x")])]], 0)]);
+    assert_eq!(md, "|  |  |\n| --- | --- |\n| `left \\| right` | x |\n");
+}
+
+#[test]
+fn code_block_pipes_cannot_split_table_cells() {
+    let cell = Cell::new(vec![Block::CodeBlock { text: "a | b".into(), lang: None }]);
+    let md =
+        doc(vec![table_from(vec![vec![cell, Cell::from_inlines(vec![Inline::plain("x")])]], 0)]);
+    assert_eq!(md, "|  |  |\n| --- | --- |\n| `a \\| b` | x |\n");
+}
+
+#[test]
 fn url_angle_brackets_are_encoded_without_bracketing() {
     let md = doc(vec![Block::Paragraph(vec![Inline::Link {
         content: vec![Inline::plain("link")],


### PR DESCRIPTION
## Summary
- escape pipes inside inline code spans rendered in GFM table cells
- use the same table-cell protection for code blocks flattened into table cells
- add focused renderer regressions for both inline code and code blocks

Fixes #84.

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --locked
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes pipes in inline code and in code blocks rendered inside GFM table cells so they no longer split cells. Previously we emitted raw pipes in these contexts; now we render them as \| while preserving backtick fencing. Non-table contexts are unchanged.

**Notes for review**
- Inline renderer: in table-cell context, route code spans through a new code-path that escapes '|' before choosing the backtick fence.
- Table renderer: apply the same escape when flattening code blocks into table cells.
- Tests: add focused regressions for inline code and code blocks to confirm pipes cannot split table cells.

<sup>Written for commit db419ab0eadf5b607334f3710d098ddc123fb6a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

