### PR TITLE
fix(epub): read a repeated spine part once

### DIFF
--- a/src/formats/epub/mod.rs
+++ b/src/formats/epub/mod.rs
@@ -44,32 +44,33 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
     // still publication content, and unusable parts degrade at parse time.
     // Intra-book links target these; links to any other resource stay
     // Relative.
-    let spine_hrefs: Vec<&str> = opf
+    // A part holds one position in a reading order, and each repeat would
+    // cost another parse of it and another copy of its anchor.
+    let mut spine_entries = 0usize;
+    let mut spine_paths: Vec<String> = Vec::new();
+    let mut spine_parts: HashSet<String> = HashSet::new();
+    for href in opf
         .descendants_any("itemref")
         .filter_map(|ir| ir.attr_any("idref"))
         .filter_map(|idref| manifest.get(idref))
         .map(|(href, _)| href.as_str())
-        .collect();
-    let spine_parts: HashSet<String> = spine_hrefs
-        .iter()
-        .filter_map(|href| path::resolve(&opf_path, href).ok().map(|t| t.path))
-        .collect();
+    {
+        spine_entries += 1;
+        let Ok(target) = path::resolve(&opf_path, href) else {
+            log::warn!("skipping chapter with unresolvable href {href:?}");
+            continue;
+        };
+        if spine_parts.insert(target.path.clone()) {
+            spine_paths.push(target.path);
+        }
+    }
 
     let assets = RefCell::new(AssetSink::new());
     let mut css_cache: HashMap<String, Option<String>> = HashMap::new();
-    let mut failed = 0usize;
-    for href in &spine_hrefs {
-        let chapter_path = match path::resolve(&opf_path, href) {
-            Ok(t) => t.path,
-            Err(e) => {
-                log::warn!("skipping chapter with unresolvable href {href:?}: {e}");
-                failed += 1;
-                continue;
-            }
-        };
-        let Some(tree) = pkg.borrow_mut().optional_xml_part(&chapter_path)? else {
+    let mut converted = 0usize;
+    for chapter_path in &spine_paths {
+        let Some(tree) = pkg.borrow_mut().optional_xml_part(chapter_path)? else {
             log::warn!("skipping unusable chapter {chapter_path}");
-            failed += 1;
             continue;
         };
         let Some(body) = tree
@@ -78,10 +79,9 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
             .and_then(|h| h.child_elems().find(|e| e.local == "body"))
         else {
             log::warn!("skipping chapter {chapter_path}: no body element");
-            failed += 1;
             continue;
         };
-        let css = chapter_stylesheet(&tree, &chapter_path, &pkg, &mut css_cache)?;
+        let css = chapter_stylesheet(&tree, chapter_path, &pkg, &mut css_cache)?;
         let ctx = ChapterCtx {
             pkg: &pkg,
             assets: &assets,
@@ -91,8 +91,9 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
         // Chapter-start anchor: renders only when a link targets this chapter.
         doc.blocks.push(Block::Paragraph(vec![Inline::Anchor(chapter_path.clone())]));
         doc.blocks.extend(crate::shared::html::to_blocks(body, &css, &ctx)?);
+        converted += 1;
     }
-    if !spine_hrefs.is_empty() && failed == spine_hrefs.len() {
+    if spine_entries > 0 && converted == 0 {
         return Err(ConvertError::malformed("no chapter in the book could be read"));
     }
 
@@ -204,5 +205,61 @@ fn scoped(chapter_path: &str, fragment: Option<&str>) -> AnchorId {
     match fragment {
         Some(f) if !f.is_empty() => format!("{chapter_path}#{f}"),
         _ => chapter_path.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+
+    #[test]
+    fn a_part_repeated_across_the_spine_is_read_once() {
+        let items: String = (0..64)
+            .map(|i| {
+                format!(r#"<item id="i{i}" href="ch.xhtml" media-type="application/xhtml+xml"/>"#)
+            })
+            .collect();
+        let refs: String = (0..64).map(|i| format!(r#"<itemref idref="i{i}"/>"#)).collect();
+        let parts = [
+            (
+                "META-INF/container.xml",
+                r#"<?xml version="1.0"?>
+                <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                <rootfiles><rootfile full-path="c.opf"
+                media-type="application/oebps-package+xml"/></rootfiles></container>"#
+                    .to_string(),
+            ),
+            (
+                "c.opf",
+                format!(
+                    r#"<?xml version="1.0"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0"><metadata/>
+                    <manifest>{items}</manifest><spine>{refs}</spine></package>"#
+                ),
+            ),
+            (
+                "ch.xhtml",
+                r#"<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml">
+                <body><p>chapter text</p></body></html>"#
+                    .to_string(),
+            ),
+        ];
+        let mut w = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        for (name, body) in &parts {
+            w.start_file(*name, zip::write::SimpleFileOptions::default()).unwrap();
+            w.write_all(body.as_bytes()).unwrap();
+        }
+
+        let doc = parse(&w.finish().unwrap().into_inner()).unwrap();
+        let text = doc
+            .blocks
+            .iter()
+            .filter_map(|b| match b {
+                Block::Paragraph(inlines) => Some(crate::model::inlines_to_plain_text(inlines)),
+                _ => None,
+            })
+            .collect::<String>();
+        assert_eq!(text, "chapter text", "sixty-four itemrefs naming one part");
     }
 }

--- a/src/formats/epub/mod.rs
+++ b/src/formats/epub/mod.rs
@@ -56,9 +56,12 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
         .map(|(href, _)| href.as_str())
     {
         spine_entries += 1;
-        let Ok(target) = path::resolve(&opf_path, href) else {
-            log::warn!("skipping chapter with unresolvable href {href:?}");
-            continue;
+        let target = match path::resolve(&opf_path, href) {
+            Ok(t) => t,
+            Err(e) => {
+                log::warn!("skipping chapter with unresolvable href {href:?}: {e}");
+                continue;
+            }
         };
         if spine_parts.insert(target.path.clone()) {
             spine_paths.push(target.path);


### PR DESCRIPTION
The spine was never deduplicated, so n itemrefs naming one href parsed it n times. In the reported file that href is the package document itself, whose size grows with n, so a 35 KB book took 27 seconds and a 69 KB one did not finish.

Itemrefs now resolve to a part path once and dedupe on it, which also catches two hrefs spelling the same part differently.

This closes a second case the issue does not cover: pointed at a real chapter instead of the package document, the same file rendered that chapter n times, emitting one anchor id n times and turning 19 KB of input into 3.2 MB of output. Duplicate anchor ids make intra-book links ambiguous.

n=6400 goes from 27s to 0.01s, n=12800 from not finishing to 0.4s, and the amplified case from 3.2 MB to 1011 bytes.

Closes #43

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates EPUB spine entries by resolved part path so a repeated part is parsed and rendered once. Previously each repeated `itemref` re-parsed and re-rendered the same part (often the package document), duplicating anchors and causing severe slowdowns; now each unique part is processed once in first-occurrence order.

- Resolves each `itemref` to a path and de-duplicates entries that resolve to the same part (including differently spelled hrefs), preserving first occurrence order.
- Error handling: tracks total spine entries and converted chapters; returns an error only if none convert; warns on unresolvable or unusable chapters, and now includes the resolve error detail in the warning.
- Adds a test asserting 64 repeated `itemref`s yield a single chapter’s text; performance improves from 27s→0.01s at n=6400 and from hang→0.4s at n=12800; amplified output drops from 3.2 MB to 1011 bytes.
- Closes #43.

<sup>Written for commit 903e00946260594e29e545d4d2cea753d06cab33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

