### PR TITLE
fix(markdown): escape pipes in code spans inside table cells

### DIFF
--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -178,14 +178,15 @@ pub(crate) fn escape_url_as_text(url: &str, ctx: InlineContext) -> String {
     )
 }
 
-/// Escape the pipes in a code span's text so the row cannot split on them.
+/// Prepare a code span's text for a table cell, where a pipe is the only
+/// character between the fences that is still syntax.
 ///
 /// A backslash run already sitting in front of a pipe would pair off with the
 /// escape and leave the pipe bare, so it is doubled to keep the escape intact.
 /// That doubling survives into the rendered code span: GFM has no encoding for
 /// a code span that contains a backslash immediately before a pipe, and an
 /// intact row is worth more than the exact backslash count.
-pub(crate) fn escape_cell_pipes(text: &str) -> String {
+pub(crate) fn escape_cell_code_span(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut backslashes = 0;
     for c in text.chars() {

--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -179,6 +179,32 @@ pub(crate) fn escape_url_as_text(url: &str, ctx: InlineContext) -> String {
 }
 
 /// Shortest backtick fence longer than any backtick run in `text`.
+/// Escape the pipes in a code span's text so the row cannot split on them.
+///
+/// A backslash run already sitting in front of a pipe would pair off with the
+/// escape and leave the pipe bare, so it is doubled to keep the escape intact.
+/// That doubling survives into the rendered code span: GFM has no encoding for
+/// a code span that contains a backslash immediately before a pipe, and an
+/// intact row is worth more than the exact backslash count.
+pub(crate) fn escape_cell_pipes(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut backslashes = 0;
+    for c in text.chars() {
+        match c {
+            '|' => {
+                for _ in 0..=backslashes {
+                    out.push('\\');
+                }
+                backslashes = 0;
+            }
+            '\\' => backslashes += 1,
+            _ => backslashes = 0,
+        }
+        out.push(c);
+    }
+    out
+}
+
 pub(crate) fn backtick_fence(text: &str, min: usize) -> String {
     let longest_run = text.split(|c| c != '`').map(str::len).max().unwrap_or(0);
     "`".repeat((longest_run + 1).max(min))

--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -178,7 +178,6 @@ pub(crate) fn escape_url_as_text(url: &str, ctx: InlineContext) -> String {
     )
 }
 
-/// Shortest backtick fence longer than any backtick run in `text`.
 /// Escape the pipes in a code span's text so the row cannot split on them.
 ///
 /// A backslash run already sitting in front of a pipe would pair off with the
@@ -205,6 +204,7 @@ pub(crate) fn escape_cell_pipes(text: &str) -> String {
     out
 }
 
+/// Shortest backtick fence longer than any backtick run in `text`.
 pub(crate) fn backtick_fence(text: &str, min: usize) -> String {
     let longest_run = text.split(|c| c != '`').map(str::len).max().unwrap_or(0);
     "`".repeat((longest_run + 1).max(min))

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -3,7 +3,8 @@
 use crate::model::{ImageSource, Inline, LinkTarget, Style, inlines_are_empty};
 use crate::render::markdown::Ctx;
 use crate::render::markdown::escape::{
-    EscapeOpts, InlineContext, backtick_fence, escape_text, escape_url_as_text, format_url,
+    EscapeOpts, InlineContext, backtick_fence, escape_cell_pipes, escape_text, escape_url_as_text,
+    format_url,
 };
 use std::borrow::Cow;
 use std::fmt::Write as _;
@@ -243,30 +244,4 @@ pub(crate) fn push_code_span(text: &str, ctx: InlineContext, out: &mut String) {
         _ => text,
     };
     let _ = write!(out, "{fence}{pad}{text}{pad}{fence}");
-}
-
-/// Escape the pipes in a code span's text so the row cannot split on them.
-///
-/// A backslash run already sitting in front of a pipe would pair off with the
-/// escape and leave the pipe bare, so it is doubled to keep the escape intact.
-/// That doubling survives into the rendered code span: GFM has no encoding for
-/// a code span that contains a backslash immediately before a pipe, and an
-/// intact row is worth more than the exact backslash count.
-fn escape_cell_pipes(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut backslashes = 0;
-    for c in text.chars() {
-        match c {
-            '|' => {
-                for _ in 0..=backslashes {
-                    out.push('\\');
-                }
-                backslashes = 0;
-            }
-            '\\' => backslashes += 1,
-            _ => backslashes = 0,
-        }
-        out.push(c);
-    }
-    out
 }

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -205,7 +205,7 @@ fn render_text_run(
     }
     if !core.is_empty() {
         if style.code {
-            push_code_span(core, out);
+            push_code_span(core, ctx, out);
         } else {
             let mut open = String::new();
             if style.strike {
@@ -232,9 +232,15 @@ fn render_text_run(
     }
 }
 
-pub(crate) fn push_code_span(text: &str, out: &mut String) {
+pub(crate) fn push_code_span(text: &str, ctx: InlineContext, out: &mut String) {
     let text = text.replace('\n', " ");
     let fence = backtick_fence(&text, 1);
     let pad = if text.starts_with('`') || text.ends_with('`') { " " } else { "" };
+    // A row is split into cells before any code span is parsed, so a pipe is
+    // syntax here even though everything else between the fences is literal.
+    let text = match ctx {
+        InlineContext::TableCell => text.replace('|', "\\|"),
+        _ => text,
+    };
     let _ = write!(out, "{fence}{pad}{text}{pad}{fence}");
 }

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -3,8 +3,8 @@
 use crate::model::{ImageSource, Inline, LinkTarget, Style, inlines_are_empty};
 use crate::render::markdown::Ctx;
 use crate::render::markdown::escape::{
-    EscapeOpts, InlineContext, backtick_fence, escape_cell_pipes, escape_text, escape_url_as_text,
-    format_url,
+    EscapeOpts, InlineContext, backtick_fence, escape_cell_code_span, escape_text,
+    escape_url_as_text, format_url,
 };
 use std::borrow::Cow;
 use std::fmt::Write as _;
@@ -240,7 +240,7 @@ pub(crate) fn push_code_span(text: &str, ctx: InlineContext, out: &mut String) {
     // A row is split into cells before any code span is parsed, so a pipe is
     // syntax here even though everything else between the fences is literal.
     let text = match ctx {
-        InlineContext::TableCell => escape_cell_pipes(&text),
+        InlineContext::TableCell => escape_cell_code_span(&text),
         _ => text,
     };
     let _ = write!(out, "{fence}{pad}{text}{pad}{fence}");

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -239,8 +239,34 @@ pub(crate) fn push_code_span(text: &str, ctx: InlineContext, out: &mut String) {
     // A row is split into cells before any code span is parsed, so a pipe is
     // syntax here even though everything else between the fences is literal.
     let text = match ctx {
-        InlineContext::TableCell => text.replace('|', "\\|"),
+        InlineContext::TableCell => escape_cell_pipes(&text),
         _ => text,
     };
     let _ = write!(out, "{fence}{pad}{text}{pad}{fence}");
+}
+
+/// Escape the pipes in a code span's text so the row cannot split on them.
+///
+/// A backslash run already sitting in front of a pipe would pair off with the
+/// escape and leave the pipe bare, so it is doubled to keep the escape intact.
+/// That doubling survives into the rendered code span: GFM has no encoding for
+/// a code span that contains a backslash immediately before a pipe, and an
+/// intact row is worth more than the exact backslash count.
+fn escape_cell_pipes(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut backslashes = 0;
+    for c in text.chars() {
+        match c {
+            '|' => {
+                for _ in 0..=backslashes {
+                    out.push('\\');
+                }
+                backslashes = 0;
+            }
+            '\\' => backslashes += 1,
+            _ => backslashes = 0,
+        }
+        out.push(c);
+    }
+    out
 }

--- a/src/render/markdown/table.rs
+++ b/src/render/markdown/table.rs
@@ -5,7 +5,7 @@
 use crate::model::{Block, Cell, CellSlot, Table};
 use crate::render::markdown::Ctx;
 use crate::render::markdown::escape::InlineContext;
-use crate::render::markdown::inline::render_inlines;
+use crate::render::markdown::inline::{push_code_span, render_inlines};
 
 struct RenderedCell {
     text: String,
@@ -166,7 +166,7 @@ fn cell_block_text(block: &Block, rc: &Ctx, parts: &mut Vec<String>) {
             let t = text.trim();
             if !t.is_empty() {
                 let mut s = String::new();
-                crate::render::markdown::inline::push_code_span(t, &mut s);
+                push_code_span(t, InlineContext::TableCell, &mut s);
                 parts.push(s);
             }
         }

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -296,6 +296,21 @@ fn url_pipes_cannot_split_table_cells() {
 }
 
 #[test]
+fn code_span_pipes_cannot_split_table_cells() {
+    let md = doc(vec![table_from(
+        vec![vec![
+            Cell::from_inlines(vec![Inline::Text {
+                text: "a | b".into(),
+                style: Style { code: true, ..Style::PLAIN },
+            }]),
+            Cell::from_inlines(vec![Inline::plain("or")]),
+        ]],
+        0,
+    )]);
+    assert_eq!(md, "|  |  |\n| --- | --- |\n| `a \\| b` | or |\n");
+}
+
+#[test]
 fn url_angle_brackets_are_encoded_without_bracketing() {
     let md = doc(vec![Block::Paragraph(vec![Inline::Link {
         content: vec![Inline::plain("link")],

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -297,17 +297,14 @@ fn url_pipes_cannot_split_table_cells() {
 
 #[test]
 fn code_span_pipes_cannot_split_table_cells() {
-    let md = doc(vec![table_from(
-        vec![vec![
-            Cell::from_inlines(vec![Inline::Text {
-                text: "a | b".into(),
-                style: Style { code: true, ..Style::PLAIN },
-            }]),
-            Cell::from_inlines(vec![Inline::plain("or")]),
-        ]],
-        0,
-    )]);
-    assert_eq!(md, "|  |  |\n| --- | --- |\n| `a \\| b` | or |\n");
+    let code = |t: &str| {
+        Cell::from_inlines(vec![Inline::Text {
+            text: t.into(),
+            style: Style { code: true, ..Style::PLAIN },
+        }])
+    };
+    let md = doc(vec![table_from(vec![vec![code("a | b"), code(r"a \| b")]], 0)]);
+    assert_eq!(md, concat!("|  |  |\n", "| --- | --- |\n", r"| `a \| b` | `a \\\| b` |", "\n"));
 }
 
 #[test]


### PR DESCRIPTION
A row is split into cells before any inline is parsed, so a pipe is syntax inside a code span too. Plain text, styled text and URLs already escaped it in a cell; code spans did not, because `push_code_span` was the one emitter that never received the context it was rendering into.

Both cell code paths route through it, the inline `code` run and a `<pre>` block in a cell, so passing the context fixes both.

Before, on a two-column table:

    | `a | b` | bitwise or |

The delimiter row declares two columns and the body row emits three, so a GFM renderer drops `bitwise or` and tears the code span in half. After:

    | `a \| b` | bitwise or |

Closes #84

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes pipes in Markdown code spans inside table cells so they no longer split columns. Previously, a pipe in a cell code span acted as a delimiter; now it renders as \|, and an existing \| renders as \\\| to preserve the escape. Code outside tables is unchanged.

- Pass `InlineContext` into `push_code_span` and escape only for `InlineContext::TableCell`.
- Route both inline code and cell `<pre>` code through `push_code_span`; add tests for "a | b" and pre-escaped "a \| b".
- Move and rename the escaper to `escape.rs` as `escape_cell_code_span`; restore the `backtick_fence` doc comment.

<sup>Written for commit 85d36060e8eb77fca9206da4b6879bf0f6b235c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

