### PR TITLE
fix(markdown): escape delimiters that pair across run seams

### DIFF
--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -63,6 +63,12 @@ impl Delims {
         }
     }
 
+    pub(crate) fn union(&mut self, other: Delims) {
+        for (slot, set) in self.0.iter_mut().zip(other.0) {
+            *slot |= set;
+        }
+    }
+
     fn contains(self, slot: usize) -> bool {
         self.0[slot]
     }

--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -23,25 +23,67 @@ pub(crate) struct EscapeOpts {
     /// The character following the run is unknown or active markup; pairable
     /// delimiters must assume the worst.
     pub trailing_active: bool,
+    /// The rest of the line starts with a non-whitespace character that is
+    /// not active markup (a hard break's backslash, an anchor tag), so a
+    /// run-final delimiter can still be left-flanking.
+    pub trailing_nonspace: bool,
+    /// Delimiters that later runs on the same rendered line will emit; a
+    /// delimiter in this run can pair with one of them across the run seam.
+    pub trailing_delims: Delims,
     /// Inside a link label / image alt, where an unmatched `]` (or `[`)
     /// would terminate the label early.
     pub in_label: bool,
 }
 
+/// Set of pairable delimiter characters (`*` `_` `~` `` ` `` `]`).
+#[derive(Clone, Copy, Default)]
+pub(crate) struct Delims([bool; 5]);
+
+impl Delims {
+    fn slot(c: char) -> Option<usize> {
+        match c {
+            '*' => Some(0),
+            '_' => Some(1),
+            '~' => Some(2),
+            '`' => Some(3),
+            ']' => Some(4),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn insert(&mut self, c: char) {
+        if let Some(slot) = Self::slot(c) {
+            self.0[slot] = true;
+        }
+    }
+
+    pub(crate) fn insert_text(&mut self, text: &str) {
+        for c in text.chars() {
+            self.insert(c);
+        }
+    }
+
+    fn contains(self, slot: usize) -> bool {
+        self.0[slot]
+    }
+}
+
 /// Escape Markdown syntax in document text.
 pub(crate) fn escape_text(text: &str, ctx: InlineContext, opts: EscapeOpts) -> String {
-    let EscapeOpts { at_line_start, styled, trailing_active, in_label } = opts;
+    let EscapeOpts {
+        at_line_start,
+        styled,
+        trailing_active,
+        trailing_nonspace,
+        trailing_delims,
+        in_label,
+    } = opts;
     let chars: Vec<char> = text.chars().collect();
     // Last position of each pairable delimiter; a lone one is inert.
     let mut last: [Option<usize>; 5] = [None; 5]; // * _ ~ ` ]
     for (j, &c) in chars.iter().enumerate() {
-        match c {
-            '*' => last[0] = Some(j),
-            '_' => last[1] = Some(j),
-            '~' => last[2] = Some(j),
-            '`' => last[3] = Some(j),
-            ']' => last[4] = Some(j),
-            _ => {}
+        if let Some(slot) = Delims::slot(c) {
+            last[slot] = Some(j);
         }
     }
     let mut out = String::with_capacity(text.len() + 8);
@@ -63,8 +105,11 @@ pub(crate) fn escape_text(text: &str, ctx: InlineContext, opts: EscapeOpts) -> S
         }
         let next = chars.get(i + 1).copied();
         // At the run's end the next character is unknown; trailing_active assumes the worst.
-        let next_nonspace = next.map_or(trailing_active, |n| !n.is_whitespace());
-        let paired = |slot: usize| trailing_active || last[slot].is_some_and(|j| j > i);
+        let next_nonspace =
+            next.map_or(trailing_active || trailing_nonspace, |n| !n.is_whitespace());
+        let paired = |slot: usize| {
+            trailing_active || trailing_delims.contains(slot) || last[slot].is_some_and(|j| j > i)
+        };
         let escape = match c {
             '\\' => true,
             ']' if in_label => true,

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -3,7 +3,7 @@
 use crate::model::{ImageSource, Inline, LinkTarget, Style, inlines_are_empty};
 use crate::render::markdown::Ctx;
 use crate::render::markdown::escape::{
-    EscapeOpts, InlineContext, backtick_fence, escape_cell_code_span, escape_text,
+    Delims, EscapeOpts, InlineContext, backtick_fence, escape_cell_code_span, escape_text,
     escape_url_as_text, format_url,
 };
 use std::borrow::Cow;
@@ -89,14 +89,26 @@ fn render_inlines_mode(inlines: &[Inline], ctx: InlineContext, in_label: bool, r
     for (idx, run) in runs.iter().enumerate() {
         match run {
             Norm::Text { text, style } => {
-                let next_active = matches!(
-                    runs.get(idx + 1),
-                    Some(Norm::Link { .. } | Norm::Image { .. } | Norm::NoteRef(_))
-                ) || matches!(
-                    runs.get(idx + 1),
-                    Some(Norm::Text { style, .. }) if *style != Style::PLAIN
-                );
-                render_text_run(text, *style, ctx, next_active, in_label, &mut out)
+                let next = runs.get(idx + 1);
+                let next_active =
+                    matches!(next, Some(Norm::Link { .. } | Norm::Image { .. } | Norm::NoteRef(_)))
+                        || matches!(
+                            next,
+                            Some(Norm::Text { style, .. }) if *style != Style::PLAIN
+                        );
+                // A hard break renders as `\`, an anchor as `<a ...>`: not
+                // markup, but a nonspace character a run-final delimiter can
+                // be left-flanking against.
+                let next_nonspace = matches!(next, Some(Norm::Anchor(_)))
+                    || (matches!(next, Some(Norm::LineBreak)) && ctx != InlineContext::Heading);
+                let opts = EscapeOpts {
+                    trailing_active: next_active,
+                    trailing_nonspace: next_nonspace,
+                    trailing_delims: delims_ahead(&runs[idx + 1..]),
+                    in_label,
+                    ..Default::default()
+                };
+                render_text_run(text, *style, ctx, opts, &mut out)
             }
             Norm::NoteRef(id) => {
                 if let Some(num) = rc.nums.get(*id) {
@@ -180,22 +192,79 @@ fn render_image(
     }
 }
 
+/// Pairable delimiters the remaining runs will emit into the current rendered
+/// line: literal characters in plain text, plus the markup that styled runs,
+/// code spans, links and images produce. A delimiter in an earlier run can
+/// pair with any of them across the run seam, hard breaks included.
+fn delims_ahead(runs: &[Norm]) -> Delims {
+    let mut delims = Delims::default();
+    for run in runs {
+        match run {
+            Norm::Text { style, .. } if style.code => delims.insert('`'),
+            Norm::Text { text, style } if *style == Style::PLAIN => delims.insert_text(text),
+            Norm::Text { text, style } => {
+                // Emphasis content is fully escaped; only the wrapping
+                // delimiters and a literal `]` reach the output raw.
+                if style.bold || style.italic {
+                    delims.insert('*');
+                }
+                if style.strike {
+                    delims.insert('~');
+                }
+                if text.contains(']') {
+                    delims.insert(']');
+                }
+            }
+            // Emphasis cannot cross a link boundary, but a code span can: a
+            // backtick in the label or destination pairs with one outside.
+            Norm::Link { content, target } => {
+                if emits_backtick(content) || target_has_backtick(target) {
+                    delims.insert('`');
+                }
+            }
+            Norm::Image { alt, source } => match source {
+                ImageSource::External(_) if alt.contains('`') => delims.insert('`'),
+                ImageSource::External(_) => {}
+                // Sourceless images degrade to their alt as plain text.
+                ImageSource::Asset(_) | ImageSource::Unavailable => delims.insert_text(alt),
+            },
+            Norm::NoteRef(_) | Norm::Anchor(_) | Norm::LineBreak => {}
+        }
+    }
+    delims
+}
+
+fn target_has_backtick(target: &LinkTarget) -> bool {
+    match target {
+        LinkTarget::External(url) | LinkTarget::Relative(url) => url.contains('`'),
+        LinkTarget::Anchor(_) => false,
+    }
+}
+
+/// True when rendering `inlines` inside a link label leaves a raw backtick in
+/// the output (label escaping leaves a lone backtick alone).
+fn emits_backtick(inlines: &[Inline]) -> bool {
+    inlines.iter().any(|inline| match inline {
+        Inline::Text { text, style } => style.code || text.contains('`'),
+        Inline::Link { content, target } => emits_backtick(content) || target_has_backtick(target),
+        Inline::Image { alt, .. } => alt.contains('`'),
+        _ => false,
+    })
+}
+
 /// Emit a styled run, moving edge whitespace outside the delimiters.
+/// `opts` carries the trailing context; `at_line_start` and `styled` are
+/// filled in here.
 fn render_text_run(
     text: &str,
     style: Style,
     ctx: InlineContext,
-    trailing_active: bool,
-    in_label: bool,
+    opts: EscapeOpts,
     out: &mut String,
 ) {
     if style == Style::PLAIN {
         let at_line_start = out.is_empty() || out.ends_with('\n');
-        out.push_str(&escape_text(
-            text,
-            ctx,
-            EscapeOpts { at_line_start, trailing_active, in_label, ..Default::default() },
-        ));
+        out.push_str(&escape_text(text, ctx, EscapeOpts { at_line_start, ..opts }));
         return;
     }
     let core_start = text.len() - text.trim_start().len();
@@ -223,7 +292,7 @@ fn render_text_run(
             out.push_str(&escape_text(
                 core,
                 ctx,
-                EscapeOpts { styled: true, in_label, ..Default::default() },
+                EscapeOpts { styled: true, in_label: opts.in_label, ..Default::default() },
             ));
             out.push_str(&close);
         }

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -85,6 +85,7 @@ pub(crate) fn render_inlines(inlines: &[Inline], ctx: InlineContext, rc: &Ctx) -
 
 fn render_inlines_mode(inlines: &[Inline], ctx: InlineContext, in_label: bool, rc: &Ctx) -> String {
     let runs = normalize(inlines, rc);
+    let suffix = delims_ahead(&runs, rc);
     let mut out = String::new();
     for (idx, run) in runs.iter().enumerate() {
         match run {
@@ -104,7 +105,7 @@ fn render_inlines_mode(inlines: &[Inline], ctx: InlineContext, in_label: bool, r
                 let opts = EscapeOpts {
                     trailing_active: next_active,
                     trailing_nonspace: next_nonspace,
-                    trailing_delims: delims_ahead(&runs[idx + 1..], rc),
+                    trailing_delims: suffix[idx + 1],
                     in_label,
                     ..Default::default()
                 };
@@ -196,53 +197,66 @@ fn render_image(
 /// line: literal characters in plain text, plus the markup that styled runs,
 /// code spans, links and images produce. A delimiter in an earlier run can
 /// pair with any of them across the run seam, hard breaks included.
-fn delims_ahead(runs: &[Norm], rc: &Ctx) -> Delims {
+/// The delimiters each suffix of `runs` emits, indexed by where the suffix
+/// starts, so one reverse pass answers every run's lookahead.
+fn delims_ahead(runs: &[Norm], rc: &Ctx) -> Vec<Delims> {
+    let mut suffix = vec![Delims::default(); runs.len() + 1];
+    for idx in (0..runs.len()).rev() {
+        let mut delims = suffix[idx + 1];
+        delims.union(delims_of(&runs[idx], rc));
+        suffix[idx] = delims;
+    }
+    suffix
+}
+
+/// What one run contributes to a later run's pairing partners.
+fn delims_of(run: &Norm, rc: &Ctx) -> Delims {
     let mut delims = Delims::default();
-    for run in runs {
-        match run {
-            Norm::Text { style, .. } if style.code => delims.insert('`'),
-            Norm::Text { text, style } if *style == Style::PLAIN => delims.insert_text(text),
-            Norm::Text { text, style } => {
-                // Emphasis content is escaped, which neutralizes everything
-                // but backticks: code spans ignore backslash escapes, so an
-                // emitted `\`` still closes a span an earlier raw backtick
-                // opens. `]` is the one character escaping leaves raw.
-                if style.bold || style.italic {
-                    delims.insert('*');
-                }
-                if style.strike {
-                    delims.insert('~');
-                }
-                if text.contains('`') {
-                    delims.insert('`');
-                }
-                if text.contains(']') {
-                    delims.insert(']');
+    match run {
+        Norm::Text { style, .. } if style.code => delims.insert('`'),
+        Norm::Text { text, style } if *style == Style::PLAIN => delims.insert_text(text),
+        Norm::Text { text, style } => {
+            // Emphasis content is escaped, which neutralizes everything
+            // but backticks: code spans ignore backslash escapes, so an
+            // emitted `\`` still closes a span an earlier raw backtick
+            // opens. `]` is the one character escaping leaves raw.
+            if style.bold || style.italic {
+                delims.insert('*');
+            }
+            if style.strike {
+                delims.insert('~');
+            }
+            if text.contains('`') {
+                delims.insert('`');
+            }
+            if text.contains(']') {
+                delims.insert(']');
+            }
+        }
+        Norm::Link { content, target } => match target {
+            // An unresolved target degrades to its rendered content
+            // (see render_link), which emits like any sibling runs.
+            LinkTarget::Anchor(id) if rc.anchors.fragment(id).is_none() => {
+                for run in &normalize(content, rc) {
+                    delims.union(delims_of(run, rc));
                 }
             }
-            Norm::Link { content, target } => match target {
-                // An unresolved target degrades to its rendered content
-                // (see render_link), which emits like any sibling runs.
-                LinkTarget::Anchor(id) if rc.anchors.fragment(id).is_none() => {
-                    delims.union(delims_ahead(&normalize(content, rc), rc));
+            // Emphasis cannot cross a link boundary, but a code span
+            // can: a backtick in the label or destination pairs with
+            // one outside.
+            _ => {
+                if emits_backtick(content) || target_has_backtick(target) {
+                    delims.insert('`');
                 }
-                // Emphasis cannot cross a link boundary, but a code span
-                // can: a backtick in the label or destination pairs with
-                // one outside.
-                _ => {
-                    if emits_backtick(content) || target_has_backtick(target) {
-                        delims.insert('`');
-                    }
-                }
-            },
-            Norm::Image { alt, source } => match source {
-                ImageSource::External(_) if alt.contains('`') => delims.insert('`'),
-                ImageSource::External(_) => {}
-                // Sourceless images degrade to their alt as plain text.
-                ImageSource::Asset(_) | ImageSource::Unavailable => delims.insert_text(alt),
-            },
-            Norm::NoteRef(_) | Norm::Anchor(_) | Norm::LineBreak => {}
-        }
+            }
+        },
+        Norm::Image { alt, source } => match source {
+            ImageSource::External(_) if alt.contains('`') => delims.insert('`'),
+            ImageSource::External(_) => {}
+            // Sourceless images degrade to their alt as plain text.
+            ImageSource::Asset(_) | ImageSource::Unavailable => delims.insert_text(alt),
+        },
+        Norm::NoteRef(_) | Norm::Anchor(_) | Norm::LineBreak => {}
     }
     delims
 }

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -203,13 +203,18 @@ fn delims_ahead(runs: &[Norm], rc: &Ctx) -> Delims {
             Norm::Text { style, .. } if style.code => delims.insert('`'),
             Norm::Text { text, style } if *style == Style::PLAIN => delims.insert_text(text),
             Norm::Text { text, style } => {
-                // Emphasis content is fully escaped; only the wrapping
-                // delimiters and a literal `]` reach the output raw.
+                // Emphasis content is escaped, which neutralizes everything
+                // but backticks: code spans ignore backslash escapes, so an
+                // emitted `\`` still closes a span an earlier raw backtick
+                // opens. `]` is the one character escaping leaves raw.
                 if style.bold || style.italic {
                     delims.insert('*');
                 }
                 if style.strike {
                     delims.insert('~');
+                }
+                if text.contains('`') {
+                    delims.insert('`');
                 }
                 if text.contains(']') {
                     delims.insert(']');
@@ -249,11 +254,15 @@ fn target_has_backtick(target: &LinkTarget) -> bool {
     }
 }
 
-/// True when rendering `inlines` inside a link label leaves a raw backtick in
-/// the output (label escaping leaves a lone backtick alone).
+/// True when rendering `inlines` inside a link label emits a backtick an
+/// earlier raw one can pair with: any backtick in text counts even where the
+/// label escapes it (code spans ignore backslash escapes), and a code run
+/// emits fences unless it is whitespace-only and loses its styling.
 fn emits_backtick(inlines: &[Inline]) -> bool {
     inlines.iter().any(|inline| match inline {
-        Inline::Text { text, style } => style.code || text.contains('`'),
+        Inline::Text { text, style } => {
+            text.contains('`') || (style.code && !text.trim().is_empty())
+        }
         Inline::Link { content, target } => emits_backtick(content) || target_has_backtick(target),
         Inline::Image { alt, .. } => alt.contains('`'),
         _ => false,

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -104,7 +104,7 @@ fn render_inlines_mode(inlines: &[Inline], ctx: InlineContext, in_label: bool, r
                 let opts = EscapeOpts {
                     trailing_active: next_active,
                     trailing_nonspace: next_nonspace,
-                    trailing_delims: delims_ahead(&runs[idx + 1..]),
+                    trailing_delims: delims_ahead(&runs[idx + 1..], rc),
                     in_label,
                     ..Default::default()
                 };
@@ -196,7 +196,7 @@ fn render_image(
 /// line: literal characters in plain text, plus the markup that styled runs,
 /// code spans, links and images produce. A delimiter in an earlier run can
 /// pair with any of them across the run seam, hard breaks included.
-fn delims_ahead(runs: &[Norm]) -> Delims {
+fn delims_ahead(runs: &[Norm], rc: &Ctx) -> Delims {
     let mut delims = Delims::default();
     for run in runs {
         match run {
@@ -215,13 +215,21 @@ fn delims_ahead(runs: &[Norm]) -> Delims {
                     delims.insert(']');
                 }
             }
-            // Emphasis cannot cross a link boundary, but a code span can: a
-            // backtick in the label or destination pairs with one outside.
-            Norm::Link { content, target } => {
-                if emits_backtick(content) || target_has_backtick(target) {
-                    delims.insert('`');
+            Norm::Link { content, target } => match target {
+                // An unresolved target degrades to its rendered content
+                // (see render_link), which emits like any sibling runs.
+                LinkTarget::Anchor(id) if rc.anchors.fragment(id).is_none() => {
+                    delims.union(delims_ahead(&normalize(content, rc), rc));
                 }
-            }
+                // Emphasis cannot cross a link boundary, but a code span
+                // can: a backtick in the label or destination pairs with
+                // one outside.
+                _ => {
+                    if emits_backtick(content) || target_has_backtick(target) {
+                        delims.insert('`');
+                    }
+                }
+            },
             Norm::Image { alt, source } => match source {
                 ImageSource::External(_) if alt.contains('`') => delims.insert('`'),
                 ImageSource::External(_) => {}

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -119,6 +119,31 @@ fn delimiters_do_not_pair_across_run_seams() {
 }
 
 #[test]
+fn unresolved_link_fallback_counts_toward_seam_pairing() {
+    // The fallback text supplies the `]` that pairs with the earlier `[`.
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("[click"),
+        Inline::LineBreak,
+        Inline::Link {
+            content: vec![Inline::plain("here]")],
+            target: LinkTarget::Anchor("nowhere".into()),
+        },
+        Inline::plain("(https://e.test)"),
+    ])]);
+    assert_eq!(md, "\\[click\\\nhere](https://e.test)\n");
+    // Same seam with an emphasis delimiter in the fallback.
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("a *"),
+        Inline::LineBreak,
+        Inline::Link {
+            content: vec![Inline::plain("b*")],
+            target: LinkTarget::Anchor("nowhere".into()),
+        },
+    ])]);
+    assert_eq!(md, "a \\*\\\nb*\n");
+}
+
+#[test]
 fn bold_trailing_space_moved_out() {
     let md = doc(vec![Block::Paragraph(vec![styled("bold ", BOLD), Inline::plain("plain")])]);
     assert_eq!(md, "**bold** plain\n");

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -144,6 +144,28 @@ fn unresolved_link_fallback_counts_toward_seam_pairing() {
 }
 
 #[test]
+fn escaped_backtick_in_later_run_still_pairs() {
+    // A styled run's backtick is emitted as `\\``, yet still closes a span
+    // an earlier raw backtick opens: code spans ignore backslash escapes.
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("a `"),
+        Inline::LineBreak,
+        styled("x`y", BOLD),
+    ])]);
+    assert_eq!(md, "a \\`\\\n**x\\`y**\n");
+    // A whitespace-only code run loses its styling and emits no fence.
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("a `"),
+        Inline::LineBreak,
+        Inline::Link {
+            content: vec![styled("  ", Style { code: true, ..Style::PLAIN }), Inline::plain("x")],
+            target: LinkTarget::External("https://e.test".into()),
+        },
+    ])]);
+    assert_eq!(md, "a `\\\n[  x](https://e.test)\n");
+}
+
+#[test]
 fn bold_trailing_space_moved_out() {
     let md = doc(vec![Block::Paragraph(vec![styled("bold ", BOLD), Inline::plain("plain")])]);
     assert_eq!(md, "**bold** plain\n");

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -94,6 +94,31 @@ fn trailing_delimiter_before_styled_run_escaped() {
 }
 
 #[test]
+fn delimiters_do_not_pair_across_run_seams() {
+    // Two lines each ending in a backtick must not form a code span (#45).
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("a `"),
+        Inline::LineBreak,
+        Inline::plain("b `"),
+    ])]);
+    assert_eq!(md, "a \\`\\\nb `\n");
+    // Emphasis pairs across a hard break just as code spans do.
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("a *"),
+        Inline::LineBreak,
+        Inline::plain("b*"),
+    ])]);
+    assert_eq!(md, "a \\*\\\nb*\n");
+    // A raw backtick pairs with a later code span's fence.
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("a `"),
+        Inline::LineBreak,
+        styled("x", Style { code: true, ..Style::PLAIN }),
+    ])]);
+    assert_eq!(md, "a \\`\\\n`x`\n");
+}
+
+#[test]
 fn bold_trailing_space_moved_out() {
     let md = doc(vec![Block::Paragraph(vec![styled("bold ", BOLD), Inline::plain("plain")])]);
     assert_eq!(md, "**bold** plain\n");


### PR DESCRIPTION
Two literal backticks in one paragraph became a code span. A Word paragraph of two lines each ending in a backtick rendered as `a <code>\ b </code>`, and a pasted code fence came back as a code span.

`escape_text` decided a delimiter was inert from the single run it was handed, so the last one in a run went out raw. Runs are concatenated into one paragraph, so two independently inert delimiters paired across the seam. `trailing_active` was meant to cover this and only fired when the next run was a link, image or styled run.

The scan now covers the runs that follow, counting both a literal delimiter in their text and one they emit as markup: a later code run emits real backticks, a later bold run emits asterisks. It also covers `*`, `_`, `~` and `]`, which shared the same logic.

Escaping stays minimal, so ordinary prose gains no backslashes and no snapshot changed.

Closes #45

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Markdown delimiters from pairing across run seams, so adjacent runs no longer create code spans, emphasis, or prematurely closed link labels across line breaks. Previously `escape_text` evaluated each run alone and let a trailing delimiter go out raw, which then paired with later literals or emitted markup.

- Covers `*`, `_`, `~`, `` ` ``, and `]`; scans following runs for both literal delimiters and those they emit (styled runs, code spans, links, images), including unresolved link fallback text. Counts backticks in later runs even when escaped (code spans ignore escapes). Treats anchors and hard breaks as nonspace for left-flanking.
- Adds `trailing_nonspace` and `trailing_delims` to `EscapeOpts`; `render_inlines` computes them with a single reverse `delims_ahead` pass per paragraph using a `Delims` set. Escaping remains minimal; ordinary prose unchanged. Tests cover hard-break seams, unresolved link fallback, and escaped backticks.

<sup>Written for commit a4530332575ee932b3edff48ad10d3009bc20786. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

