### PR TITLE
fix(markdown): pair emphasis delimiters only with closer-capable partners

### DIFF
--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -91,17 +91,32 @@ fn partner_slot(chars: &[char], j: usize) -> Option<usize> {
 }
 
 /// Whether the emphasis or strikethrough delimiter at `j` could close a
-/// pair: approximate right-flanking (not preceded by whitespace), plus the
-/// intraword exclusion for `_`. Unknown neighbours at the edges assume the
-/// worst.
+/// pair. Flanking is a property of the whole delimiter run, so the
+/// neighbours are the run's: approximate right-flanking (not preceded by
+/// whitespace, nor preceded by punctuation with a word character after),
+/// plus the intraword exclusion for `_`. Unknown neighbours at the edges
+/// assume the worst; the punctuation test stays ASCII so an unclassified
+/// character never suppresses a genuine closer.
 fn can_close(chars: &[char], j: usize) -> bool {
-    let prev = j.checked_sub(1).map(|p| chars[p]);
+    let c = chars[j];
+    let mut start = j;
+    while start > 0 && chars[start - 1] == c {
+        start -= 1;
+    }
+    let mut end = j + 1;
+    while end < chars.len() && chars[end] == c {
+        end += 1;
+    }
+    let prev = start.checked_sub(1).map(|p| chars[p]);
+    let next = chars.get(end).copied();
     if prev.is_some_and(char::is_whitespace) {
         return false;
     }
-    chars[j] != '_'
-        || !(prev.is_some_and(char::is_alphanumeric)
-            && chars.get(j + 1).is_some_and(|n| n.is_alphanumeric()))
+    if prev.is_some_and(|p| p.is_ascii_punctuation()) && next.is_some_and(char::is_alphanumeric) {
+        return false;
+    }
+    c != '_'
+        || !(prev.is_some_and(char::is_alphanumeric) && next.is_some_and(char::is_alphanumeric))
 }
 
 /// Escape Markdown syntax in document text.

--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -57,9 +57,15 @@ impl Delims {
         }
     }
 
-    pub(crate) fn insert_text(&mut self, text: &str) {
-        for c in text.chars() {
-            self.insert(c);
+    /// Record the partners `text` contributes when emitted as document
+    /// text: every backtick and `]`, plus the emphasis delimiters that
+    /// can close.
+    pub(crate) fn insert_closers(&mut self, text: &str) {
+        let chars: Vec<char> = text.chars().collect();
+        for j in 0..chars.len() {
+            if let Some(slot) = partner_slot(&chars, j) {
+                self.0[slot] = true;
+            }
         }
     }
 
@@ -74,6 +80,30 @@ impl Delims {
     }
 }
 
+/// Slot for the delimiter at `j` when it can act as a pairing partner.
+/// Backticks and `]` always can: code spans pair by backtick-string length
+/// (even a backslash-escaped backtick still closes one) and brackets pair
+/// as link structure. `*`, `_` and `~` pair by flanking, so they only
+/// count where they can close.
+fn partner_slot(chars: &[char], j: usize) -> Option<usize> {
+    let slot = Delims::slot(chars[j])?;
+    (matches!(chars[j], '`' | ']') || can_close(chars, j)).then_some(slot)
+}
+
+/// Whether the emphasis or strikethrough delimiter at `j` could close a
+/// pair: approximate right-flanking (not preceded by whitespace), plus the
+/// intraword exclusion for `_`. Unknown neighbours at the edges assume the
+/// worst.
+fn can_close(chars: &[char], j: usize) -> bool {
+    let prev = j.checked_sub(1).map(|p| chars[p]);
+    if prev.is_some_and(char::is_whitespace) {
+        return false;
+    }
+    chars[j] != '_'
+        || !(prev.is_some_and(char::is_alphanumeric)
+            && chars.get(j + 1).is_some_and(|n| n.is_alphanumeric()))
+}
+
 /// Escape Markdown syntax in document text.
 pub(crate) fn escape_text(text: &str, ctx: InlineContext, opts: EscapeOpts) -> String {
     let EscapeOpts {
@@ -85,10 +115,11 @@ pub(crate) fn escape_text(text: &str, ctx: InlineContext, opts: EscapeOpts) -> S
         in_label,
     } = opts;
     let chars: Vec<char> = text.chars().collect();
-    // Last position of each pairable delimiter; a lone one is inert.
+    // Last position of each delimiter that can pair; one with no later
+    // partner is inert.
     let mut last: [Option<usize>; 5] = [None; 5]; // * _ ~ ` ]
-    for (j, &c) in chars.iter().enumerate() {
-        if let Some(slot) = Delims::slot(c) {
+    for j in 0..chars.len() {
+        if let Some(slot) = partner_slot(&chars, j) {
             last[slot] = Some(j);
         }
     }

--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -62,10 +62,13 @@ impl Delims {
     /// can close.
     pub(crate) fn insert_closers(&mut self, text: &str) {
         let chars: Vec<char> = text.chars().collect();
-        for j in 0..chars.len() {
-            if let Some(slot) = partner_slot(&chars, j) {
+        let mut j = 0;
+        while j < chars.len() {
+            let end = run_end(&chars, j);
+            if let Some(slot) = partner_slot(&chars, j, end) {
                 self.0[slot] = true;
             }
+            j = end;
         }
     }
 
@@ -80,34 +83,33 @@ impl Delims {
     }
 }
 
-/// Slot for the delimiter at `j` when it can act as a pairing partner.
+/// End of the run of identical characters starting at `j`.
+fn run_end(chars: &[char], j: usize) -> usize {
+    let mut end = j + 1;
+    while end < chars.len() && chars[end] == chars[j] {
+        end += 1;
+    }
+    end
+}
+
+/// Slot for the delimiter run `j..end` when it can act as a pairing partner.
 /// Backticks and `]` always can: code spans pair by backtick-string length
 /// (even a backslash-escaped backtick still closes one) and brackets pair
 /// as link structure. `*`, `_` and `~` pair by flanking, so they only
 /// count where they can close.
-fn partner_slot(chars: &[char], j: usize) -> Option<usize> {
+fn partner_slot(chars: &[char], j: usize, end: usize) -> Option<usize> {
     let slot = Delims::slot(chars[j])?;
-    (matches!(chars[j], '`' | ']') || can_close(chars, j)).then_some(slot)
+    (matches!(chars[j], '`' | ']') || can_close(chars, j, end)).then_some(slot)
 }
 
-/// Whether the emphasis or strikethrough delimiter at `j` could close a
-/// pair. Flanking is a property of the whole delimiter run, so the
-/// neighbours are the run's: approximate right-flanking (not preceded by
-/// whitespace, nor preceded by punctuation with a word character after),
-/// plus the intraword exclusion for `_`. Unknown neighbours at the edges
-/// assume the worst; the punctuation test stays ASCII so an unclassified
-/// character never suppresses a genuine closer.
-fn can_close(chars: &[char], j: usize) -> bool {
-    let c = chars[j];
-    let mut start = j;
-    while start > 0 && chars[start - 1] == c {
-        start -= 1;
-    }
-    let mut end = j + 1;
-    while end < chars.len() && chars[end] == c {
-        end += 1;
-    }
-    let prev = start.checked_sub(1).map(|p| chars[p]);
+/// Whether the emphasis or strikethrough run `j..end` could close a pair:
+/// approximate right-flanking (not preceded by whitespace, nor preceded by
+/// punctuation with a word character after), plus the intraword exclusion
+/// for `_`. Unknown neighbours at the edges assume the worst; the
+/// punctuation test stays ASCII so an unclassified character never
+/// suppresses a genuine closer.
+fn can_close(chars: &[char], j: usize, end: usize) -> bool {
+    let prev = j.checked_sub(1).map(|p| chars[p]);
     let next = chars.get(end).copied();
     if prev.is_some_and(char::is_whitespace) {
         return false;
@@ -115,7 +117,7 @@ fn can_close(chars: &[char], j: usize) -> bool {
     if prev.is_some_and(|p| p.is_ascii_punctuation()) && next.is_some_and(char::is_alphanumeric) {
         return false;
     }
-    c != '_'
+    chars[j] != '_'
         || !(prev.is_some_and(char::is_alphanumeric) && next.is_some_and(char::is_alphanumeric))
 }
 
@@ -133,10 +135,13 @@ pub(crate) fn escape_text(text: &str, ctx: InlineContext, opts: EscapeOpts) -> S
     // Last position of each delimiter that can pair; one with no later
     // partner is inert.
     let mut last: [Option<usize>; 5] = [None; 5]; // * _ ~ ` ]
-    for j in 0..chars.len() {
-        if let Some(slot) = partner_slot(&chars, j) {
-            last[slot] = Some(j);
+    let mut j = 0;
+    while j < chars.len() {
+        let end = run_end(&chars, j);
+        if let Some(slot) = partner_slot(&chars, j, end) {
+            last[slot] = Some(end - 1);
         }
+        j = end;
     }
     let mut out = String::with_capacity(text.len() + 8);
     let mut line_has_content = !(at_line_start && ctx == InlineContext::Block);

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -194,7 +194,7 @@ fn render_image(
 }
 
 /// Pairable delimiters the remaining runs will emit into the current rendered
-/// line: literal characters in plain text, plus the markup that styled runs,
+/// line: closer-capable literals in plain text, plus the markup that styled runs,
 /// code spans, links and images produce. A delimiter in an earlier run can
 /// pair with any of them across the run seam, hard breaks included.
 /// The delimiters each suffix of `runs` emits, indexed by where the suffix
@@ -214,7 +214,7 @@ fn delims_of(run: &Norm, rc: &Ctx) -> Delims {
     let mut delims = Delims::default();
     match run {
         Norm::Text { style, .. } if style.code => delims.insert('`'),
-        Norm::Text { text, style } if *style == Style::PLAIN => delims.insert_text(text),
+        Norm::Text { text, style } if *style == Style::PLAIN => delims.insert_closers(text),
         Norm::Text { text, style } => {
             // Emphasis content is escaped, which neutralizes everything
             // but backticks: code spans ignore backslash escapes, so an
@@ -254,7 +254,7 @@ fn delims_of(run: &Norm, rc: &Ctx) -> Delims {
             ImageSource::External(_) if alt.contains('`') => delims.insert('`'),
             ImageSource::External(_) => {}
             // Sourceless images degrade to their alt as plain text.
-            ImageSource::Asset(_) | ImageSource::Unavailable => delims.insert_text(alt),
+            ImageSource::Asset(_) | ImageSource::Unavailable => delims.insert_closers(alt),
         },
         Norm::NoteRef(_) | Norm::Anchor(_) | Norm::LineBreak => {}
     }

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -64,6 +64,14 @@ fn partners_that_cannot_close_leave_delimiters_raw() {
         Inline::plain("snake_case"),
     ])]);
     assert_eq!(md, "a _\\\nsnake_case\n");
+    // A `*` after punctuation and before a word character is not
+    // right-flanking either.
+    let md = doc(vec![Block::Paragraph(vec![Inline::plain("a *b .*c")])]);
+    assert_eq!(md, "a *b .*c\n");
+    // Flanking is judged at the delimiter run's edges: `__` between
+    // letters is intraword even though each `_` neighbours the other.
+    let md = doc(vec![Block::Paragraph(vec![Inline::plain("a _x foo__bar")])]);
+    assert_eq!(md, "a _x foo__bar\n");
 }
 
 #[test]

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -46,6 +46,27 @@ fn lone_syntax_chars_left_alone() {
 }
 
 #[test]
+fn partners_that_cannot_close_leave_delimiters_raw() {
+    // The space-padded `*` is not right-flanking, so the opener is inert.
+    let md = doc(vec![Block::Paragraph(vec![Inline::plain("a *b 2 * 3")])]);
+    assert_eq!(md, "a *b 2 * 3\n");
+    // Same across a run seam.
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("a *"),
+        Inline::LineBreak,
+        Inline::plain("2 * 3"),
+    ])]);
+    assert_eq!(md, "a *\\\n2 * 3\n");
+    // Intraword underscores can neither open nor close.
+    let md = doc(vec![Block::Paragraph(vec![
+        Inline::plain("a _"),
+        Inline::LineBreak,
+        Inline::plain("snake_case"),
+    ])]);
+    assert_eq!(md, "a _\\\nsnake_case\n");
+}
+
+#[test]
 fn intraword_underscores_unescaped() {
     let md = doc(vec![Block::Paragraph(vec![Inline::plain("snake_case_name vs _lead_")])]);
     assert_eq!(md, "snake_case_name vs \\_lead_\n");


### PR DESCRIPTION
Follow-up to #113. That change extended the escaper's occurrence-based pairing across run seams; this makes both sides ask whether a partner could actually close.

`a *b 2 * 3` no longer gains a backslash, because the later `*` follows a space and can never close.

One predicate, `partner_slot`, used by the within-run scan and the cross-run scan, so the two sides cannot drift.

Flanking is an emphasis rule, so it applies to `*`, `_` and `~` only. Backticks keep occurrence-based treatment: code spans pair by fence length and an escaped backtick still closes one, which is why the escape-all-but-last strategy is what keeps them safe. Brackets pair as link structure.

No snapshot changed, and that is the right reading rather than a miss: every emphasis escape in the corpus already had a partner that can close.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pairs emphasis delimiters only with partners that can close, scanning delimiter runs and judging flanking at run edges. Previously any later `*`, `_`, or `~` forced escaping; now only right-flanking partners count and `_` cannot pair intraword. Backticks and `]` keep occurrence-based rules.

- Scan partners run-at-a-time and share partner_slot/can_close across within-run and cross-run logic to keep pairing consistent across run seams.
- Replace Delims::insert_text with Delims::insert_closers; delims_of now records only closer-capable literals in plain text and sourceless image alts.
- Keep occurrence-based pairing for backticks and `]`.
- Add tests for non-closing partners, punctuation adjacency, intraword `_`, and run seams; snapshots unchanged.

<sup>Written for commit 4ec63043e4ce19e3077f43fcc0eefe46342d1f2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

