### PR TITLE
chore: read utf-16 units through as_chunks

### DIFF
--- a/src/formats/doc/mod.rs
+++ b/src/formats/doc/mod.rs
@@ -15,7 +15,7 @@ use crate::model::{
 };
 use crate::package::limits;
 use crate::shared::assets::AssetSink;
-use crate::shared::binary::{get_u16, get_u32, read_ole_stream};
+use crate::shared::binary::{get_u16, get_u32, read_ole_stream, utf16le_units};
 use crate::shared::blockstyle::StyledRun;
 use crate::shared::delta::rebase_emphasis;
 use crate::shared::fields::{FieldFrame, field_result};
@@ -370,8 +370,7 @@ fn extract_text(
             let Some(bytes) = word_doc.get(piece.fc..).and_then(|rest| rest.get(..byte_len)) else {
                 continue;
             };
-            let units: Vec<u16> =
-                bytes.chunks_exact(2).map(|c| u16::from_le_bytes([c[0], c[1]])).collect();
+            let units: Vec<u16> = utf16le_units(bytes).collect();
             let mut unit_idx = 0usize;
             for r in char::decode_utf16(units.iter().copied()) {
                 let c = r.unwrap_or('\u{fffd}');

--- a/src/formats/doc/stsh.rs
+++ b/src/formats/doc/stsh.rs
@@ -4,7 +4,7 @@
 
 use crate::formats::doc::sprm::{PapDelta, apply_pap_sprms, apply_style_chpx};
 use crate::model::Style;
-use crate::shared::binary::{get_u16, get_u32};
+use crate::shared::binary::{get_u16, get_u32, utf16le_units};
 use crate::shared::blockstyle::{self, BlockStyle};
 use std::collections::HashMap;
 
@@ -105,14 +105,14 @@ fn parse_std(record: &[u8], cb_std_base: usize) -> Option<Std> {
     let name_len = get_u16(record, name_off)? as usize;
     // Unicode name: length prefix + UTF-16 chars + terminator.
     let name_bytes = name_len.checked_mul(2)?;
-    let name_units: Vec<u16> = record
-        .get(name_off..)
-        .and_then(|rest| rest.get(2..))
-        .and_then(|rest| rest.get(..name_bytes))
-        .unwrap_or_default()
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
-        .collect();
+    let name_units: Vec<u16> = utf16le_units(
+        record
+            .get(name_off..)
+            .and_then(|rest| rest.get(2..))
+            .and_then(|rest| rest.get(..name_bytes))
+            .unwrap_or_default(),
+    )
+    .collect();
     let name = String::from_utf16_lossy(&name_units);
     let mut upx_pos = name_off.checked_add(4)?.checked_add(name_bytes)?;
 

--- a/src/formats/ppt/mod.rs
+++ b/src/formats/ppt/mod.rs
@@ -11,7 +11,7 @@ mod styletext;
 use crate::error::ConvertError;
 use crate::model::{Block, Document, Inline, Style, inlines_are_empty};
 use crate::package::limits;
-use crate::shared::binary::{get_u32, read_ole_stream};
+use crate::shared::binary::{get_u32, read_ole_stream, utf16le_units};
 use crate::shared::delta::{StyleDelta, rebase_emphasis};
 use crate::shared::list::{ListEntry, ListKey, MarkerKind, flush_list};
 use crate::shared::officeart::record_at;
@@ -469,7 +469,7 @@ impl Extractor {
             }
             // TextCharsAtom: UTF-16LE.
             0x0FA0 => {
-                let units = body.chunks_exact(2).map(|c| u16::from_le_bytes([c[0], c[1]]));
+                let units = utf16le_units(body);
                 let text: String =
                     char::decode_utf16(units).map(|r| r.unwrap_or('\u{fffd}')).collect();
                 self.push_text(text);

--- a/src/formats/sheet/xls.rs
+++ b/src/formats/sheet/xls.rs
@@ -12,7 +12,7 @@ use super::{error_literal, rk_number};
 use crate::error::ConvertError;
 use crate::model::{Block, Document, Inline};
 use crate::package::limits;
-use crate::shared::binary::{get_u16, get_u32, read_ole_stream};
+use crate::shared::binary::{get_u16, get_u32, read_ole_stream, utf16le_units};
 use crate::shared::text::clean_text;
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -257,7 +257,7 @@ fn read_biff8_string(r: &mut SegReader, short: bool, rich: bool) -> Option<Strin
         }
         let bytes = r.bytes(take * unit)?;
         if wide {
-            units.extend(bytes.chunks_exact(2).map(|c| u16::from_le_bytes([c[0], c[1]])));
+            units.extend(utf16le_units(bytes));
         } else {
             units.extend(bytes.iter().map(|&b| u16::from(b)));
         }

--- a/src/formats/sheet/xlsb.rs
+++ b/src/formats/sheet/xlsb.rs
@@ -14,6 +14,7 @@ use crate::model::{Block, Document, Inline};
 use crate::package::limits;
 use crate::package::relationships::{read_rels, rel_type, rels_part_for};
 use crate::package::{Package, path};
+use crate::shared::binary::utf16le_units;
 use crate::shared::text::clean_text;
 use std::collections::HashMap;
 
@@ -439,7 +440,7 @@ impl<'a> Fields<'a> {
             .checked_mul(2)
             .ok_or_else(|| ConvertError::malformed("oversized string length"))
             .and_then(|n| self.take(n))?;
-        let units = bytes.chunks_exact(2).map(|pair| u16::from_le_bytes([pair[0], pair[1]]));
+        let units = utf16le_units(bytes);
         Ok(char::decode_utf16(units).map(|r| r.unwrap_or(char::REPLACEMENT_CHARACTER)).collect())
     }
 

--- a/src/shared/binary.rs
+++ b/src/shared/binary.rs
@@ -16,6 +16,11 @@ pub(crate) fn get_u32(b: &[u8], off: usize) -> Option<u32> {
     Some(u32::from_le_bytes(b.get(off..)?.get(..4)?.try_into().ok()?))
 }
 
+/// The UTF-16LE code units of `bytes`; a trailing odd byte is dropped.
+pub(crate) fn utf16le_units(bytes: &[u8]) -> impl Iterator<Item = u16> + '_ {
+    bytes.as_chunks::<2>().0.iter().map(|pair| u16::from_le_bytes(*pair))
+}
+
 /// Read a named stream from an OLE2 compound file. A missing stream is
 /// `MissingPart`; the read is hard-capped at `MAX_ENTRY_BYTES` so a corrupt
 /// sector chain cannot expand without bound.


### PR DESCRIPTION
Rust 1.98's clippy rejects `chunks_exact` with a constant size, which broke CI on main. The five UTF-16LE decoders now share one `utf16le_units` helper built on `as_chunks`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates UTF-16LE code-unit reading into `utf16le_units(bytes)` using `as_chunks`, replacing `chunks_exact(2)` to satisfy Rust 1.98 Clippy and restore CI. Behavior is unchanged; odd trailing bytes are still dropped.

- Updates decoders in DOC, PPT, XLS, and XLSB to use `utf16le_units`; adds the helper in `src/shared/binary.rs`.
- Keeps the same decoding path via `char::decode_utf16` and the same error handling.
- No public API or format behavior changes.

<sup>Written for commit bafb115305c3a746b6c8519ec79332c7363b7524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

