### PR TITLE
fix(markdown): escape a dollar only where a math span could form

### DIFF
--- a/src/render/markdown/escape.rs
+++ b/src/render/markdown/escape.rs
@@ -35,9 +35,9 @@ pub(crate) struct EscapeOpts {
     pub in_label: bool,
 }
 
-/// Set of pairable delimiter characters (`*` `_` `~` `` ` `` `]`).
+/// Set of pairable delimiter characters (`*` `_` `~` `` ` `` `]` `$`).
 #[derive(Clone, Copy, Default)]
-pub(crate) struct Delims([bool; 5]);
+pub(crate) struct Delims([bool; 6]);
 
 impl Delims {
     fn slot(c: char) -> Option<usize> {
@@ -47,6 +47,7 @@ impl Delims {
             '~' => Some(2),
             '`' => Some(3),
             ']' => Some(4),
+            '$' => Some(5),
             _ => None,
         }
     }
@@ -95,11 +96,26 @@ fn run_end(chars: &[char], j: usize) -> usize {
 /// Slot for the delimiter run `j..end` when it can act as a pairing partner.
 /// Backticks and `]` always can: code spans pair by backtick-string length
 /// (even a backslash-escaped backtick still closes one) and brackets pair
-/// as link structure. `*`, `_` and `~` pair by flanking, so they only
-/// count where they can close.
+/// as link structure. `*`, `_` and `~` pair by flanking, and `$` closes
+/// math only after a non-space and before a non-digit, so those count only
+/// where they can close.
 fn partner_slot(chars: &[char], j: usize, end: usize) -> Option<usize> {
     let slot = Delims::slot(chars[j])?;
-    (matches!(chars[j], '`' | ']') || can_close(chars, j, end)).then_some(slot)
+    let closes = match chars[j] {
+        '`' | ']' => true,
+        '$' => can_close_math(chars, j, end),
+        _ => can_close(chars, j, end),
+    };
+    closes.then_some(slot)
+}
+
+/// Whether the `$` run `j..end` could close a math span: not preceded by
+/// whitespace, not followed by a digit. Unknown neighbours at the edges
+/// assume the worst.
+fn can_close_math(chars: &[char], j: usize, end: usize) -> bool {
+    let prev = j.checked_sub(1).map(|p| chars[p]);
+    let next = chars.get(end).copied();
+    !prev.is_some_and(char::is_whitespace) && !next.is_some_and(|n| n.is_ascii_digit())
 }
 
 /// Whether the emphasis or strikethrough run `j..end` could close a pair:
@@ -134,7 +150,7 @@ pub(crate) fn escape_text(text: &str, ctx: InlineContext, opts: EscapeOpts) -> S
     let chars: Vec<char> = text.chars().collect();
     // Last position of each delimiter that can pair; one with no later
     // partner is inert.
-    let mut last: [Option<usize>; 5] = [None; 5]; // * _ ~ ` ]
+    let mut last: [Option<usize>; 6] = [None; 6]; // * _ ~ ` ] $
     let mut j = 0;
     while j < chars.len() {
         let end = run_end(&chars, j);
@@ -169,9 +185,9 @@ pub(crate) fn escape_text(text: &str, ctx: InlineContext, opts: EscapeOpts) -> S
         };
         let escape = match c {
             '\\' => true,
-            // A bare `$` could pair with an emitted math delimiter, or with
-            // another `$` in the text, into a math span.
-            '$' => true,
+            // Opens a math span only directly before non-space, and only
+            // when a `$` that can close follows.
+            '$' => next_nonspace && paired(5),
             ']' if in_label => true,
             '`' => styled || paired(3),
             '*' => styled || start_of_line || (next_nonspace && paired(0)),

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -237,6 +237,7 @@ fn delims_of(run: &Norm, rc: &Ctx) -> Delims {
             if text.contains(']') {
                 delims.insert(']');
             }
+            delims.insert_closers(&text.replace(|c: char| c != '$' && !c.is_whitespace(), "x"));
         }
         Norm::Link { content, target } => match target {
             // An unresolved target degrades to its rendered content

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -38,8 +38,14 @@ fn math_renders_in_dollar_delimiters_and_text_dollars_are_escaped() {
             Inline::plain(" holds."),
         ]),
         Block::Math("\\sum_{i=1}^{n} i $".into()),
+        Block::Paragraph(vec![Inline::plain("Plans at $20 or $17.50.")]),
+        Block::Paragraph(vec![Inline::plain("Pair $x with y$ here.")]),
     ]);
-    assert_eq!(md, "Costs \\$5 or \\$6, and $x_1 < y$ holds.\n\n$$\n\\sum_{i=1}^{n} i \\$\n$$\n");
+    assert_eq!(
+        md,
+        "Costs \\$5 or \\$6, and $x_1 < y$ holds.\n\n$$\n\\sum_{i=1}^{n} i \\$\n$$\n\n\
+         Plans at $20 or $17.50.\n\nPair \\$x with y$ here.\n"
+    );
 }
 
 #[test]

--- a/tests/snapshots/snapshots__docx__handmade-math.docx.snap
+++ b/tests/snapshots/snapshots__docx__handmade-math.docx.snap
@@ -12,4 +12,4 @@ $$
 \text{where }\mathbf{x} \in \mathbb{R}
 $$
 
-A price of \$5 or \$6 is not math.
+A price of $5 or $6 is not math.

--- a/tests/snapshots/snapshots__ods__sheet.ods.snap
+++ b/tests/snapshots/snapshots__ods__sheet.ods.snap
@@ -7,7 +7,7 @@ expression: output
 | Kind | Value | Note |
 | --- | --- | --- |
 | Percent | 15.5% | fifteen and a half |
-| Currency | \$1,234.50 | dollars |
+| Currency | $1,234.50 | dollars |
 | Thousands | 9,876,543 | grouped |
 | Date | 2026-03-15 | ides of March |
 | Duration | 26:30:15 | over a day |

--- a/tests/snapshots/snapshots__rtf__handmade-math.rtf.snap
+++ b/tests/snapshots/snapshots__rtf__handmade-math.rtf.snap
@@ -12,4 +12,4 @@ $$
 \text{where }-1<x
 $$
 
-A price of \$5 or \$6 is not math.
+A price of $5 or $6 is not math.

--- a/tests/snapshots/snapshots__xls__sheet.xls.snap
+++ b/tests/snapshots/snapshots__xls__sheet.xls.snap
@@ -7,7 +7,7 @@ expression: output
 | Kind | Value | Note |
 | --- | --- | --- |
 | Percent | 15.5% | fifteen and a half |
-| Currency | \$1,234.50 | dollars |
+| Currency | $1,234.50 | dollars |
 | Thousands | 9,876,543 | grouped |
 | Date | 2026-03-15 | ides of March |
 | Duration | 26:30:15 | over a day |

--- a/tests/snapshots/snapshots__xlsb__handmade-sheet.xlsb.snap
+++ b/tests/snapshots/snapshots__xlsb__handmade-sheet.xlsb.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 | Region | north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north north | Notes |
 | --- | --- | --- |
-| 42 | 65.0% | \$1,234.50 |
+| 42 | 65.0% | $1,234.50 |
 | 1.5 | 0.015 | 2026-03-15 |
 | wide merge |  |  |
 |  |  |  |

--- a/tests/snapshots/snapshots__xlsx__sheet.xlsx.snap
+++ b/tests/snapshots/snapshots__xlsx__sheet.xlsx.snap
@@ -7,7 +7,7 @@ expression: output
 | Kind | Value | Note |
 | --- | --- | --- |
 | Percent | 15.5% | fifteen and a half |
-| Currency | \$1,234.50 | dollars |
+| Currency | $1,234.50 | dollars |
 | Thousands | 9,876,543 | grouped |
 | Date | 2026-03-15 | ides of March |
 | Duration | 26:30:15 | over a day |


### PR DESCRIPTION
Since v0.2.1 every `$` in text came out as `\$`, so prices read `\$20.00`. A dollar now follows the same rule as the other delimiters: escaped only when it could open a math span (directly before non-space) and a `$` that could close one (after non-space, not before a digit) follows on the same line. Lone prices and `$5 and $6` stay bare.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Markdown dollar escaping so prices render correctly. Previously every `$` was escaped (e.g., `\$20.00`); now we escape `$` only when it could start a math span and a valid closing `$` could follow. Prices like `$20` remain bare; math like `$x_1 < y$` still works.

**Review notes**
- Treats `$` as a pairable delimiter: a closing `$` is valid only after non-space and not before a digit; an opening `$` escapes only if directly before non-space and a closer is detectable.
- Key cases covered by tests: `$20` and `$17.50` remain `$`; plain text `$x … y$` becomes `\$x … y$` to avoid accidental math.
- Main changes in `escape.rs` (delimiter set, partner detection, `can_close_math`, `$` escape rule) and `inline.rs` (closer detection); snapshots updated to show bare currency symbols.

<sup>Written for commit 2d6dade5f9ab18ccd3767c8f82892b0f455c2f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

