### PR TITLE
feat(model): render checkbox controls as task list tokens

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -169,6 +169,8 @@ export interface Inline {
   anchor?: string
   /** noteRef: the id of the note in `Document.notes`. */
   noteId?: string
+  /** checkbox: its state. */
+  checked?: boolean
 }
 
 export declare const enum InlineKind {
@@ -180,7 +182,9 @@ export declare const enum InlineKind {
   noteRef = 'noteRef',
   lineBreak = 'lineBreak',
   /** An inline formula. */
-  math = 'math'
+  math = 'math',
+  /** A checkbox control. */
+  checkbox = 'checkbox'
 }
 
 export interface LinkTarget {
@@ -207,8 +211,6 @@ export interface List {
 
 export interface ListItem {
   blocks: Array<Block>
-  /** Task-list state, when the item carries a checkbox. */
-  checked?: boolean
   /**
    * Literal marker text that overrides the list marker when the source
    * number text cannot be reproduced from the marker and position alone

--- a/node/src/document.rs
+++ b/node/src/document.rs
@@ -104,6 +104,8 @@ pub enum InlineKind {
     lineBreak,
     /// An inline formula.
     math,
+    /// A checkbox control.
+    checkbox,
 }
 
 #[napi(object)]
@@ -125,6 +127,8 @@ pub struct Inline {
     pub anchor: Option<String>,
     /// noteRef: the id of the note in `Document.notes`.
     pub note_id: Option<String>,
+    /// checkbox: its state.
+    pub checked: Option<bool>,
 }
 
 impl Inline {
@@ -139,6 +143,7 @@ impl Inline {
             source: None,
             anchor: None,
             note_id: None,
+            checked: None,
         }
     }
 }
@@ -169,6 +174,9 @@ impl From<model::Inline> for Inline {
             }
             model::Inline::LineBreak => Inline::of(InlineKind::lineBreak),
             model::Inline::Math(tex) => Inline { text: Some(tex), ..Inline::of(InlineKind::math) },
+            model::Inline::Checkbox(checked) => {
+                Inline { checked: Some(checked), ..Inline::of(InlineKind::checkbox) }
+            }
         }
     }
 }
@@ -300,8 +308,6 @@ impl From<model::List> for List {
 #[napi(object)]
 pub struct ListItem {
     pub blocks: Vec<Block>,
-    /// Task-list state, when the item carries a checkbox.
-    pub checked: Option<bool>,
     /// Literal marker text that overrides the list marker when the source
     /// number text cannot be reproduced from the marker and position alone
     /// (composite number text such as `1-a)`).
@@ -310,11 +316,7 @@ pub struct ListItem {
 
 impl From<model::ListItem> for ListItem {
     fn from(item: model::ListItem) -> Self {
-        ListItem {
-            blocks: blocks(item.blocks),
-            checked: item.checked,
-            marker_label: item.marker_label,
-        }
+        ListItem { blocks: blocks(item.blocks), marker_label: item.marker_label }
     }
 }
 

--- a/python/anydoc/_anydoc.pyi
+++ b/python/anydoc/_anydoc.pyi
@@ -99,9 +99,9 @@ class Block:
 
 @final
 class Inline:
-    kind: Literal["text", "link", "image", "anchor", "note_ref", "line_break", "math"]
+    kind: Literal["text", "link", "image", "anchor", "note_ref", "line_break", "math", "checkbox"]
     """`anchor` is a zero-width marker for an internal link target at this
-    position."""
+    position. `checkbox` is a checkbox control."""
     text: str | None
     style: Style | None
     """text."""
@@ -117,6 +117,8 @@ class Inline:
     """anchor: the anchor id."""
     note_id: str | None
     """note_ref: the id of the note in `Document.notes`."""
+    checked: bool | None
+    """checkbox: its state."""
 
 @final
 class Style:
@@ -158,8 +160,6 @@ class List:
 @final
 class ListItem:
     blocks: list[Block]
-    checked: bool | None
-    """Task-list state, when the item carries a checkbox."""
     marker_label: str | None
     """Literal marker text that overrides the list marker when the source
     number text cannot be reproduced from the marker and position alone

--- a/python/src/document.rs
+++ b/python/src/document.rs
@@ -107,6 +107,8 @@ pub struct Inline {
     anchor: Option<String>,
     /// note_ref: the id of the note in `Document.notes`.
     note_id: Option<String>,
+    /// checkbox: its state.
+    checked: Option<bool>,
 }
 
 impl Inline {
@@ -121,6 +123,7 @@ impl Inline {
             source: None,
             anchor: None,
             note_id: None,
+            checked: None,
         }
     }
 }
@@ -146,6 +149,9 @@ fn inline(py: Python<'_>, inline: model::Inline) -> PyResult<Inline> {
         model::Inline::NoteRef(id) => Inline { note_id: Some(id), ..Inline::of("note_ref") },
         model::Inline::LineBreak => Inline::of("line_break"),
         model::Inline::Math(tex) => Inline { text: Some(tex), ..Inline::of("math") },
+        model::Inline::Checkbox(checked) => {
+            Inline { checked: Some(checked), ..Inline::of("checkbox") }
+        }
     })
 }
 
@@ -242,8 +248,6 @@ fn list(py: Python<'_>, list: model::List) -> PyResult<List> {
 pub struct ListItem {
     /// list[Block]
     blocks: Py<PyList>,
-    /// Task-list state, when the item carries a checkbox.
-    checked: Option<bool>,
     /// Literal marker text that overrides the list marker when the source
     /// number text cannot be reproduced from the marker and position alone
     /// (composite number text such as `1-a)`).
@@ -251,11 +255,7 @@ pub struct ListItem {
 }
 
 fn list_item(py: Python<'_>, item: model::ListItem) -> PyResult<ListItem> {
-    Ok(ListItem {
-        blocks: blocks(py, item.blocks)?,
-        checked: item.checked,
-        marker_label: item.marker_label,
-    })
+    Ok(ListItem { blocks: blocks(py, item.blocks)?, marker_label: item.marker_label })
 }
 
 /// Canonical table grid: every logical grid position appears exactly once.

--- a/src/formats/odf/table.rs
+++ b/src/formats/odf/table.rs
@@ -95,6 +95,7 @@ fn block_bytes(blocks: &[Block]) -> u64 {
                 Inline::Image { alt, .. } => alt.len() as u64,
                 Inline::Math(tex) => tex.len() as u64,
                 Inline::Anchor(id) | Inline::NoteRef(id) => id.len() as u64,
+                Inline::Checkbox(_) => 3,
                 Inline::LineBreak => 1,
             })
             .sum()

--- a/src/formats/odf/text.rs
+++ b/src/formats/odf/text.rs
@@ -217,7 +217,7 @@ fn parse_list(
         }
         first_item = false;
         let label = item_label(ctx, style_name, depth, &chain);
-        current.items.push(ListItem { blocks: item_blocks, checked: None, marker_label: label });
+        current.items.push(ListItem { blocks: item_blocks, marker_label: label });
         next = current.start.saturating_add(current.items.len() as u64);
     }
     flush(&mut current, &mut out, next);

--- a/src/model/inline.rs
+++ b/src/model/inline.rs
@@ -34,6 +34,8 @@ pub enum Inline {
     LineBreak,
     /// An inline formula, as LaTeX math without delimiters.
     Math(String),
+    /// A checkbox control with its state.
+    Checkbox(bool),
 }
 
 impl Inline {
@@ -41,6 +43,11 @@ impl Inline {
     pub fn plain(text: impl Into<String>) -> Self {
         Inline::Text { text: text.into(), style: Style::PLAIN }
     }
+}
+
+/// The Markdown task-list token for a checkbox state.
+pub fn checkbox_text(checked: bool) -> &'static str {
+    if checked { "[x]" } else { "[ ]" }
 }
 
 /// Flatten inlines to their text, dropping styling and links but keeping link
@@ -59,6 +66,7 @@ fn collect_plain_text(inlines: &[Inline], out: &mut String) {
             Inline::Link { content, .. } => collect_plain_text(content, out),
             Inline::Image { alt, .. } => out.push_str(alt),
             Inline::Math(tex) => out.push_str(tex),
+            Inline::Checkbox(checked) => out.push_str(checkbox_text(*checked)),
             Inline::Anchor(_) | Inline::NoteRef(_) => {}
             Inline::LineBreak => out.push('\n'),
         }
@@ -72,7 +80,7 @@ pub fn inlines_are_empty(inlines: &[Inline]) -> bool {
     inlines.iter().all(|i| match i {
         Inline::Text { text, .. } => text.trim().is_empty(),
         Inline::Link { content, target } => target.is_empty() && inlines_are_empty(content),
-        Inline::Image { .. } | Inline::NoteRef(_) => false,
+        Inline::Image { .. } | Inline::NoteRef(_) | Inline::Checkbox(_) => false,
         Inline::Math(tex) => tex.trim().is_empty(),
         Inline::Anchor(_) | Inline::LineBreak => true,
     })

--- a/src/model/list.rs
+++ b/src/model/list.rs
@@ -115,9 +115,6 @@ impl List {
 pub struct ListItem {
     /// The item's content.
     pub blocks: Vec<Block>,
-    /// Checkbox state for a task list item; `None` when the item carries no
-    /// checkbox.
-    pub checked: Option<bool>,
     /// Literal marker text that overrides the level marker when the source
     /// number text cannot be reproduced from `marker` + position alone
     /// (composite number text such as `1-a)`).

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -15,7 +15,7 @@ mod table;
 
 pub use asset::{Asset, AssetId};
 pub use block::Block;
-pub use inline::{Inline, inlines_are_empty, inlines_to_plain_text};
+pub use inline::{Inline, checkbox_text, inlines_are_empty, inlines_to_plain_text};
 pub use link::{AnchorId, ImageSource, LinkTarget};
 pub use list::{List, ListItem, MarkerKind};
 pub use style::Style;

--- a/src/render/markdown/inline.rs
+++ b/src/render/markdown/inline.rs
@@ -1,6 +1,6 @@
 //! Inline run normalization and rendering.
 
-use crate::model::{ImageSource, Inline, LinkTarget, Style, inlines_are_empty};
+use crate::model::{ImageSource, Inline, LinkTarget, Style, checkbox_text, inlines_are_empty};
 use crate::render::markdown::Ctx;
 use crate::render::markdown::escape::{
     Delims, EscapeOpts, InlineContext, backtick_fence, escape_cell_code_span, escape_text,
@@ -17,6 +17,7 @@ pub(crate) enum Norm<'a> {
     NoteRef(&'a str),
     LineBreak,
     Math(&'a str),
+    Checkbox(bool),
 }
 
 /// Single-pass normalization: drops empty runs, strips styling from
@@ -77,6 +78,7 @@ pub(crate) fn normalize<'a>(inlines: &'a [Inline], rc: &Ctx) -> Vec<Norm<'a>> {
             Inline::LineBreak => out.push(Norm::LineBreak),
             Inline::Math(tex) if tex.trim().is_empty() => continue,
             Inline::Math(tex) => out.push(Norm::Math(tex.trim())),
+            Inline::Checkbox(checked) => out.push(Norm::Checkbox(*checked)),
         }
     }
     out
@@ -104,7 +106,7 @@ fn render_inlines_mode(inlines: &[Inline], ctx: InlineContext, in_label: bool, r
                 // A hard break renders as `\`, an anchor as `<a ...>`: not
                 // markup, but a nonspace character a run-final delimiter can
                 // be left-flanking against.
-                let next_nonspace = matches!(next, Some(Norm::Anchor(_)))
+                let next_nonspace = matches!(next, Some(Norm::Anchor(_) | Norm::Checkbox(_)))
                     || (matches!(next, Some(Norm::LineBreak)) && ctx != InlineContext::Heading);
                 let opts = EscapeOpts {
                     trailing_active: next_active,
@@ -133,6 +135,13 @@ fn render_inlines_mode(inlines: &[Inline], ctx: InlineContext, in_label: bool, r
                 InlineContext::TableCell => out.push('\n'),
             },
             Norm::Math(tex) => push_math_span(tex, ctx, &mut out),
+            Norm::Checkbox(checked) => {
+                out.push_str(checkbox_text(*checked));
+                // The token stands apart from a caption that follows it.
+                if matches!(runs.get(idx + 1), Some(run) if !starts_with_space(run)) {
+                    out.push(' ');
+                }
+            }
         }
     }
     out
@@ -262,9 +271,21 @@ fn delims_of(run: &Norm, rc: &Ctx) -> Delims {
             // Sourceless images degrade to their alt as plain text.
             ImageSource::Asset(_) | ImageSource::Unavailable => delims.insert_closers(alt),
         },
-        Norm::NoteRef(_) | Norm::Anchor(_) | Norm::LineBreak | Norm::Math(_) => {}
+        Norm::NoteRef(_)
+        | Norm::Anchor(_)
+        | Norm::LineBreak
+        | Norm::Math(_)
+        | Norm::Checkbox(_) => {}
     }
     delims
+}
+
+fn starts_with_space(run: &Norm) -> bool {
+    match run {
+        Norm::Text { text, .. } => text.starts_with(char::is_whitespace),
+        Norm::LineBreak => true,
+        _ => false,
+    }
 }
 
 fn target_has_backtick(target: &LinkTarget) -> bool {

--- a/src/render/markdown/mod.rs
+++ b/src/render/markdown/mod.rs
@@ -239,11 +239,6 @@ fn render_list(list: &List, rc: &Ctx) -> Option<String> {
             (None, MarkerKind::Decimal) => format!("{}. ", list.start.saturating_add(i as u64)),
             (None, kind) => format!("- {} ", kind.label(list.start.saturating_add(i as u64))),
         };
-        let checkbox = match item.checked {
-            Some(true) => "[x] ",
-            Some(false) => "[ ] ",
-            None => "",
-        };
         let body = render_blocks(&item.blocks, rc);
         if item.blocks.len() > 1 {
             loose = true;
@@ -251,7 +246,7 @@ fn render_list(list: &List, rc: &Ctx) -> Option<String> {
         let indent = " ".repeat(marker.chars().count());
         let mut lines = body.lines();
         let first = lines.next().unwrap_or("");
-        let mut s = format!("{marker}{checkbox}{first}");
+        let mut s = format!("{marker}{first}");
         for line in lines {
             s.push('\n');
             if line.is_empty() {

--- a/src/render/markdown/tests.rs
+++ b/src/render/markdown/tests.rs
@@ -303,7 +303,6 @@ fn composite_marker_labels_are_escaped() {
         start: 1,
         items: vec![crate::model::ListItem {
             blocks: vec![Block::Paragraph(vec![Inline::plain("x")])],
-            checked: None,
             marker_label: Some("#1\n*a*".into()),
         }],
     };
@@ -472,12 +471,10 @@ fn nested_list() {
                     start: 3,
                     items: vec![ListItem {
                         blocks: vec![Block::Paragraph(vec![Inline::plain("inner")])],
-                        checked: None,
                         marker_label: None,
                     }],
                 }),
             ],
-            checked: None,
             marker_label: None,
         }],
     })]);
@@ -488,7 +485,6 @@ fn nested_list() {
 fn roman_and_alpha_markers_render_literally() {
     let item = |text: &str| ListItem {
         blocks: vec![Block::Paragraph(vec![Inline::plain(text)])],
-        checked: None,
         marker_label: None,
     };
     let md = doc(vec![
@@ -635,7 +631,6 @@ fn an_empty_item_keeps_its_marker_and_the_numbering() {
         } else {
             vec![Block::Paragraph(vec![Inline::plain(text)])]
         },
-        checked: None,
         marker_label: None,
     };
     let md = doc(vec![Block::List(List {
@@ -659,18 +654,31 @@ fn task_list() {
         start: 1,
         items: vec![
             ListItem {
-                blocks: vec![Block::Paragraph(vec![Inline::plain("done")])],
-                checked: Some(true),
+                blocks: vec![Block::Paragraph(vec![Inline::Checkbox(true), Inline::plain("done")])],
                 marker_label: None,
             },
             ListItem {
-                blocks: vec![Block::Paragraph(vec![Inline::plain("todo")])],
-                checked: Some(false),
+                blocks: vec![Block::Paragraph(vec![
+                    Inline::Checkbox(false),
+                    Inline::plain(" todo"),
+                ])],
                 marker_label: None,
             },
         ],
     })]);
     assert_eq!(md, "- [x] done\n- [ ] todo\n");
+}
+
+#[test]
+fn checkbox_in_a_table_cell() {
+    let md = doc(vec![table_from(
+        vec![vec![
+            Cell::from_inlines(vec![Inline::Checkbox(true)]),
+            Cell::from_inlines(vec![Inline::Checkbox(false), Inline::plain("Wall")]),
+        ]],
+        0,
+    )]);
+    assert_eq!(md, "|  |  |\n| --- | --- |\n| [x] | [ ] Wall |\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/drawingml.rs
+++ b/src/shared/drawingml.rs
@@ -80,7 +80,6 @@ pub fn diagram_blocks(root: &Element) -> Vec<Block> {
             }
             Some(ListItem {
                 blocks: vec![Block::Paragraph(vec![Inline::plain(text)])],
-                checked: None,
                 marker_label: None,
             })
         })

--- a/src/shared/html.rs
+++ b/src/shared/html.rs
@@ -244,7 +244,9 @@ fn at_space_boundary(inlines: &[Inline], start: bool) -> bool {
                 }
                 return at_space_boundary(content, false);
             }
-            Inline::Image { .. } | Inline::NoteRef(_) | Inline::Math(_) => return false,
+            Inline::Image { .. } | Inline::NoteRef(_) | Inline::Math(_) | Inline::Checkbox(_) => {
+                return false;
+            }
         }
     }
     start
@@ -544,11 +546,8 @@ impl Builder<'_> {
         if !ordered {
             let mut list_items = Vec::with_capacity(items.len());
             for li in &items {
-                list_items.push(ListItem {
-                    blocks: self.sub_blocks(li, delta)?,
-                    checked: None,
-                    marker_label: None,
-                });
+                list_items
+                    .push(ListItem { blocks: self.sub_blocks(li, delta)?, marker_label: None });
             }
             let list = List { marker: MarkerKind::Bullet, start: 1, items: list_items };
             return Ok(vec![Block::List(list)]);
@@ -584,7 +583,6 @@ impl Builder<'_> {
             for (li, &n) in items.iter().zip(&numbers) {
                 list_items.push(ListItem {
                     blocks: self.sub_blocks(li, delta)?,
-                    checked: None,
                     marker_label: Some(format!("{n}.")),
                 });
             }
@@ -594,8 +592,7 @@ impl Builder<'_> {
         let mut current: Option<List> = None;
         let mut last_number = 0i64;
         for (li, &number) in items.iter().zip(&numbers) {
-            let item =
-                ListItem { blocks: self.sub_blocks(li, delta)?, checked: None, marker_label: None };
+            let item = ListItem { blocks: self.sub_blocks(li, delta)?, marker_label: None };
             let contiguous = current.is_some() && last_number.checked_add(1) == Some(number);
             if !contiguous {
                 if let Some(list) = current.take() {

--- a/src/shared/list.rs
+++ b/src/shared/list.rs
@@ -81,11 +81,7 @@ fn build_lists(entries: Vec<ListEntry>) -> Vec<Block> {
                 current = Some((list, key, number));
             }
             let (list, _, last) = current.as_mut().unwrap();
-            list.items.push(ListItem {
-                blocks: entry.blocks,
-                checked: None,
-                marker_label: entry.label,
-            });
+            list.items.push(ListItem { blocks: entry.blocks, marker_label: entry.label });
             *last = number;
         } else {
             let mut sub = Vec::new();

--- a/wasm/src/document.rs
+++ b/wasm/src/document.rs
@@ -112,6 +112,8 @@ pub enum InlineKind {
     LineBreak,
     /// An inline formula.
     Math,
+    /// A checkbox control.
+    Checkbox,
 }
 
 #[derive(Serialize)]
@@ -142,6 +144,9 @@ pub struct Inline {
     /// noteRef: the id of the note in `Document.notes`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub note_id: Option<String>,
+    /// checkbox: its state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checked: Option<bool>,
 }
 
 impl Inline {
@@ -156,6 +161,7 @@ impl Inline {
             source: None,
             anchor: None,
             note_id: None,
+            checked: None,
         }
     }
 }
@@ -186,6 +192,9 @@ impl From<model::Inline> for Inline {
             }
             model::Inline::LineBreak => Inline::of(InlineKind::LineBreak),
             model::Inline::Math(tex) => Inline { text: Some(tex), ..Inline::of(InlineKind::Math) },
+            model::Inline::Checkbox(checked) => {
+                Inline { checked: Some(checked), ..Inline::of(InlineKind::Checkbox) }
+            }
         }
     }
 }
@@ -321,9 +330,6 @@ impl From<model::List> for List {
 #[serde(rename_all = "camelCase")]
 pub struct ListItem {
     pub blocks: Vec<Block>,
-    /// Task-list state, when the item carries a checkbox.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub checked: Option<bool>,
     /// Literal marker text that overrides the list marker when the source
     /// number text cannot be reproduced from the marker and position alone
     /// (composite number text such as `1-a)`).
@@ -333,11 +339,7 @@ pub struct ListItem {
 
 impl From<model::ListItem> for ListItem {
     fn from(item: model::ListItem) -> Self {
-        ListItem {
-            blocks: blocks(item.blocks),
-            checked: item.checked,
-            marker_label: item.marker_label,
-        }
+        ListItem { blocks: blocks(item.blocks), marker_label: item.marker_label }
     }
 }
 

--- a/wasm/src/typescript.rs
+++ b/wasm/src/typescript.rs
@@ -75,6 +75,8 @@ export type InlineKind =
   | 'lineBreak'
   /** An inline formula. */
   | 'math'
+  /** A checkbox control. */
+  | 'checkbox'
 
 export interface Inline {
   kind: InlineKind
@@ -94,6 +96,8 @@ export interface Inline {
   anchor?: string
   /** noteRef: the id of the note in `Document.notes`. */
   noteId?: string
+  /** checkbox: its state. */
+  checked?: boolean
 }
 
 /** Fully resolved character style. */
@@ -155,8 +159,6 @@ export interface List {
 
 export interface ListItem {
   blocks: Array<Block>
-  /** Task-list state, when the item carries a checkbox. */
-  checked?: boolean
   /**
    * Literal marker text that overrides the list marker when the source
    * number text cannot be reproduced from the marker and position alone


### PR DESCRIPTION
Checkbox controls had no home in the model: `ListItem.checked` existed but no reader set it, and readers about to extract form controls (spreadsheets, docx form fields, html inputs) would each have hand-built `[x]`.

Adds `Inline::Checkbox(bool)`, rendered as `[x]` / `[ ]` by the Markdown renderer, and folds `ListItem.checked` into it: a task list item is a list item whose content starts with a checkbox.

Watch: `ListItem.checked` is removed from the public model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes checkbox modeling by adding `Inline::Checkbox(bool)` and removing `ListItem.checked`. Markdown now renders checkboxes as task-list tokens in content; list rendering no longer injects checkbox state from the item.

- Model: add `Inline::Checkbox` and `checkbox_text(bool)`; plain text includes the token; `inlines_are_empty` treats checkboxes as non-empty.
- Rendering: Markdown outputs `[x]`/`[ ]` and inserts a separating space before following text when needed; task-list appearance comes from an inline checkbox at the start of the first paragraph; table cells render tokens; delimiter logic unchanged.
- Bindings: Node, Python, and WASM/TypeScript add `Inline.kind = 'checkbox'` and `Inline.checked?: boolean`; remove `ListItem.checked` from all APIs.
- Other formats: ODF byte sizing counts a checkbox as length 3; ODF and HTML list builders stop setting `checked`; HTML space-boundary handling treats checkboxes as non-whitespace content.
- Tests: update task-list cases; add checkbox-in-table coverage.

Bold migrations:
- Replace all uses of `ListItem.checked` by inserting `Inline::Checkbox(true|false)` as the first inline of the item's first paragraph.
- Readers extracting form controls must emit `Inline::Checkbox` instead of literal `[x]`/`[ ]`.
- Update consumers to read `Inline.kind === 'checkbox'` and `Inline.checked` and remove any reads of `ListItem.checked`.

<sup>Written for commit 784760305fdea379aff2b6f8b6884a4db204a0d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

