### PR TITLE
feat(pdf): per-page markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install @firecrawl/anydoc
 ```
 
 ```js
-import { toDocument, toMarkdown, toMarkdownBytes } from '@firecrawl/anydoc';
+import { toDocument, toMarkdown, toMarkdownBytes, toMarkdownPages } from '@firecrawl/anydoc';
 
 // From a file path:
 const markdown = await toMarkdown('report.docx');
@@ -54,6 +54,9 @@ const fromCsv = await toMarkdownBytes(bytes, 'csv');
 
 // Or stop at the document model, which also carries embedded assets:
 const document = await toDocument(bytes);
+
+// A PDF can also come out one page at a time, marking the pages that need OCR:
+const pages = await toMarkdownPages(bytes);
 ```
 
 > Full API reference: [node/README.md](node/README.md)
@@ -78,6 +81,9 @@ markdown = anydoc.to_markdown_bytes(data, "csv")
 
 # Or stop at the document model, which also carries embedded assets:
 document = anydoc.to_document(data)
+
+# A PDF can also come out one page at a time, marking the pages that need OCR:
+pages = anydoc.to_markdown_pages(data)
 ```
 
 > Full API reference: [python/README.md](python/README.md)
@@ -89,7 +95,7 @@ npm install @firecrawl/anydoc-wasm
 ```
 
 ```js
-import init, { toMarkdownBytes, toDocument } from '@firecrawl/anydoc-wasm';
+import init, { toMarkdownBytes, toMarkdownPages, toDocument } from '@firecrawl/anydoc-wasm';
 
 await init();
 
@@ -101,6 +107,9 @@ const fromCsv = toMarkdownBytes(bytes, 'csv');
 
 // Or stop at the document model, which also carries embedded assets:
 const document = toDocument(bytes);
+
+// A PDF can also come out one page at a time, marking the pages that need OCR:
+const pages = toMarkdownPages(bytes);
 ```
 
 > Full API reference: [wasm/README.md](wasm/README.md)
@@ -123,6 +132,9 @@ let markdown = anydoc::to_markdown_bytes(&bytes, anydoc::Format::Csv)?;
 
 // Or stop at the document model, which also carries embedded assets:
 let document = anydoc::to_document(&bytes, None)?;
+
+// A PDF can also come out one page at a time, marking the pages that need OCR:
+let pages = anydoc::to_markdown_pages(&bytes)?;
 ```
 
 ## Features

--- a/node/README.md
+++ b/node/README.md
@@ -39,7 +39,7 @@ Markdown goes to stdout, errors to stderr, and `anydoc --help` covers the rest.
 ## Usage
 
 ```js
-import { toDocument, toMarkdown, toMarkdownBytes } from '@firecrawl/anydoc';
+import { toDocument, toMarkdown, toMarkdownBytes, toMarkdownPages } from '@firecrawl/anydoc';
 
 // From a file path:
 const markdown = await toMarkdown('report.docx');
@@ -52,6 +52,9 @@ const fromCsv = await toMarkdownBytes(bytes, 'csv');
 
 // Or stop at the document model, which also carries embedded assets:
 const document = await toDocument(bytes);
+
+// A PDF can also come out one page at a time, marking the pages that need OCR:
+const pages = await toMarkdownPages(bytes);
 ```
 
 ## Errors

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -255,6 +255,22 @@ export declare const enum NoteKind {
   endnote = 'endnote'
 }
 
+/** One page of a PDF, from `toMarkdownPages`. */
+export interface Page {
+  /** 1-indexed page number. */
+  number: number
+  /**
+   * What could be extracted from the page: unreliable or empty when it
+   * needs OCR.
+   */
+  markdown: string
+  /**
+   * The page is scanned or image-only and needs OCR, which anydoc does
+   * not do.
+   */
+  needsOcr: boolean
+}
+
 /** Fully resolved character style. */
 export interface Style {
   bold: boolean
@@ -311,3 +327,14 @@ export declare function toMarkdown(path: string): Promise<string>
  * Rejects with an `Error` carrying a `ConvertErrorCode` on `code`.
  */
 export declare function toMarkdownBytes(bytes: Uint8Array, format?: Format | undefined | null): Promise<string>
+
+/**
+ * Convert a PDF to Markdown one page at a time, marking the pages that need
+ * OCR instead of rejecting the document: for attributing output to its page,
+ * and for taking the text pages of a partly scanned document.
+ *
+ * Unsupported for every other format.
+ *
+ * Rejects with an `Error` carrying a `ConvertErrorCode` on `code`.
+ */
+export declare function toMarkdownPages(bytes: Uint8Array): Promise<Page[]>

--- a/node/index.js
+++ b/node/index.js
@@ -715,3 +715,4 @@ module.exports.TableKind = nativeBinding.TableKind
 module.exports.toDocument = nativeBinding.toDocument
 module.exports.toMarkdown = nativeBinding.toMarkdown
 module.exports.toMarkdownBytes = nativeBinding.toMarkdownBytes
+module.exports.toMarkdownPages = nativeBinding.toMarkdownPages

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -135,6 +135,37 @@ pub fn to_document(bytes: Uint8Array, format: Option<Format>) -> AsyncTask<Docum
     })
 }
 
+/// One page of a PDF, from `toMarkdownPages`.
+#[napi(object)]
+pub struct Page {
+    /// 1-indexed page number.
+    pub number: u32,
+    /// What could be extracted from the page: unreliable or empty when it
+    /// needs OCR.
+    pub markdown: String,
+    /// The page is scanned or image-only and needs OCR, which anydoc does
+    /// not do.
+    pub needs_ocr: bool,
+}
+
+impl From<anydoc::Page> for Page {
+    fn from(page: anydoc::Page) -> Self {
+        Page { number: page.number, markdown: page.markdown, needs_ocr: page.needs_ocr }
+    }
+}
+
+/// Convert a PDF to Markdown one page at a time, marking the pages that need
+/// OCR instead of rejecting the document: for attributing output to its page,
+/// and for taking the text pages of a partly scanned document.
+///
+/// Unsupported for every other format.
+///
+/// Rejects with an `Error` carrying a `ConvertErrorCode` on `code`.
+#[napi(ts_return_type = "Promise<Page[]>")]
+pub fn to_markdown_pages(bytes: Uint8Array) -> AsyncTask<PagesTask> {
+    AsyncTask::new(PagesTask { bytes: bytes.to_vec(), failure: Failure::default() })
+}
+
 /// The kind of a failed conversion, held between the two threads a rejection
 /// crosses: `compute` runs on the libuv pool, where there is no `Env` to build
 /// a JS error with, and `reject` runs on the JS thread, where there is.
@@ -218,6 +249,28 @@ impl Task for MarkdownBytesTask {
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
         Ok(output)
+    }
+
+    fn reject(&mut self, env: Env, error: Error) -> Result<Self::JsValue> {
+        Err(self.failure.reject(env, error))
+    }
+}
+
+pub struct PagesTask {
+    bytes: Vec<u8>,
+    failure: Failure,
+}
+
+impl Task for PagesTask {
+    type Output = Vec<anydoc::Page>;
+    type JsValue = Vec<Page>;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        anydoc::to_markdown_pages(&self.bytes).map_err(|e| self.failure.capture(e))
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output.into_iter().map(Page::from).collect())
     }
 
     fn reject(&mut self, env: Env, error: Error) -> Result<Self::JsValue> {

--- a/node/test.mjs
+++ b/node/test.mjs
@@ -15,6 +15,7 @@ import {
   toDocument,
   toMarkdown,
   toMarkdownBytes,
+  toMarkdownPages,
 } from './index.js'
 
 const fixture = (name) => fileURLToPath(new URL(`../tests/fixtures/${name}`, import.meta.url))
@@ -92,6 +93,12 @@ test('a pdf with scanned pages rejects naming them instead of dropping them', as
     assert.deepEqual([error.pages, error.pageCount], [[2], 2])
     return true
   })
+})
+
+test('toMarkdownPages keeps the text pages of a partly scanned pdf', async () => {
+  const pages = await toMarkdownPages(await readFile(MIXED))
+  assert.deepEqual(pages.map((page) => [page.number, page.needsOcr]), [[1, false], [2, true]])
+  assert.match(pages[0].markdown, /Text on the first page/)
 })
 
 const CLI = fileURLToPath(new URL('./cli.js', import.meta.url))

--- a/python/README.md
+++ b/python/README.md
@@ -42,6 +42,9 @@ markdown = anydoc.to_markdown_bytes(data, "csv")
 
 # Or stop at the document model, which also carries embedded assets:
 document = anydoc.to_document(data)
+
+# A PDF can also come out one page at a time, marking the pages that need OCR:
+pages = anydoc.to_markdown_pages(data)
 ```
 
 ## Errors

--- a/python/anydoc/__init__.py
+++ b/python/anydoc/__init__.py
@@ -19,6 +19,7 @@ from anydoc._anydoc import (
     MissingPartError,
     NeedsOcrError,
     Note,
+    Page,
     ResourceLimitError,
     Style,
     Table,
@@ -29,6 +30,7 @@ from anydoc._anydoc import (
     to_document,
     to_markdown,
     to_markdown_bytes,
+    to_markdown_pages,
 )
 
 Format = Literal[
@@ -56,6 +58,7 @@ __all__ = [
     "MissingPartError",
     "NeedsOcrError",
     "Note",
+    "Page",
     "ResourceLimitError",
     "Style",
     "Table",
@@ -66,4 +69,5 @@ __all__ = [
     "to_document",
     "to_markdown",
     "to_markdown_bytes",
+    "to_markdown_pages",
 ]

--- a/python/anydoc/_anydoc.pyi
+++ b/python/anydoc/_anydoc.pyi
@@ -71,6 +71,13 @@ def to_markdown_bytes(data: bytes | bytearray, format: Format | None = None) -> 
     detected from the content, which signature-less formats (CSV) have to
     name explicitly."""
 
+def to_markdown_pages(data: bytes | bytearray) -> list[Page]:
+    """Convert a PDF to Markdown one page at a time, marking the pages that
+    need OCR instead of raising for the document: for attributing output to
+    its page, and for taking the text pages of a partly scanned document.
+
+    Unsupported for every other format."""
+
 def to_document(data: bytes | bytearray, format: Format | None = None) -> Document:
     """Parse an in-memory document into the document model, which also
     carries the embedded assets. Without a format, it is detected from the
@@ -78,6 +85,19 @@ def to_document(data: bytes | bytearray, format: Format | None = None) -> Docume
 
     Unsupported for `pdf`: PDF conversion produces Markdown directly and has
     no document-model form; use `to_markdown_bytes`."""
+
+@final
+class Page:
+    """One page of a PDF, from `to_markdown_pages`."""
+
+    number: int
+    """1-indexed page number."""
+    markdown: str
+    """What could be extracted from the page: unreliable or empty when it
+    needs OCR."""
+    needs_ocr: bool
+    """The page is scanned or image-only and needs OCR, which anydoc does
+    not do."""
 
 @final
 class Document:

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -195,6 +195,37 @@ fn to_document(
     document::document(py, parsed)
 }
 
+/// One page of a PDF, from `to_markdown_pages`.
+#[pyclass(frozen, get_all, module = "anydoc")]
+struct Page {
+    /// 1-indexed page number.
+    number: u32,
+    /// What could be extracted from the page: unreliable or empty when it
+    /// needs OCR.
+    markdown: String,
+    /// The page is scanned or image-only and needs OCR, which anydoc does
+    /// not do.
+    needs_ocr: bool,
+}
+
+/// Convert a PDF to Markdown one page at a time, marking the pages that need
+/// OCR instead of raising for the document: for attributing output to its
+/// page, and for taking the text pages of a partly scanned document.
+///
+/// Unsupported for every other format.
+#[pyfunction]
+fn to_markdown_pages(py: Python<'_>, data: Vec<u8>) -> PyResult<Vec<Page>> {
+    let pages = py.detach(|| anydoc::to_markdown_pages(&data)).map_err(|e| convert_error(py, e))?;
+    Ok(pages
+        .into_iter()
+        .map(|page| Page {
+            number: page.number,
+            markdown: page.markdown,
+            needs_ocr: page.needs_ocr,
+        })
+        .collect())
+}
+
 /// Convert documents to GitHub-Flavored Markdown.
 #[pymodule]
 fn _anydoc(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -203,6 +234,7 @@ fn _anydoc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(format_from_path, m)?)?;
     m.add_function(wrap_pyfunction!(to_markdown, m)?)?;
     m.add_function(wrap_pyfunction!(to_markdown_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(to_markdown_pages, m)?)?;
     m.add_function(wrap_pyfunction!(to_document, m)?)?;
     m.add_class::<document::Asset>()?;
     m.add_class::<document::Block>()?;
@@ -215,6 +247,7 @@ fn _anydoc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<document::List>()?;
     m.add_class::<document::ListItem>()?;
     m.add_class::<document::Note>()?;
+    m.add_class::<Page>()?;
     m.add_class::<document::Style>()?;
     m.add_class::<document::Table>()?;
     m.add("ConvertError", m.py().get_type::<ConvertError>())?;

--- a/python/tests/test_anydoc.py
+++ b/python/tests/test_anydoc.py
@@ -34,6 +34,11 @@ class AnydocTest(unittest.TestCase):
             anydoc.to_markdown_bytes(CSV.read_bytes())
         self.assertIn("| --- |", anydoc.to_markdown_bytes(CSV.read_bytes(), "csv"))
 
+    def test_to_markdown_pages_keeps_the_text_pages_of_a_partly_scanned_pdf(self):
+        pages = anydoc.to_markdown_pages(MIXED.read_bytes())
+        self.assertEqual([(page.number, page.needs_ocr) for page in pages], [(1, False), (2, True)])
+        self.assertIn("Text on the first page", pages[0].markdown)
+
     def test_to_document_exposes_the_document_model(self):
         document = anydoc.to_document(OUTLINE.read_bytes(), "docx")
         heading = next(block for block in document.blocks if block.kind == "heading")

--- a/src/formats/pdf.rs
+++ b/src/formats/pdf.rs
@@ -8,6 +8,7 @@
 //!
 //! [pdf-inspector]: https://github.com/firecrawl/pdf-inspector
 
+use crate::Page;
 use crate::error::ConvertError;
 use pdf_inspector::PdfError;
 
@@ -27,17 +28,36 @@ pub fn to_markdown(bytes: &[u8]) -> Result<String, ConvertError> {
         log::warn!("broken font encodings detected; extracted text may be garbled");
     }
     match result.markdown {
-        Some(mut markdown) if !markdown.trim().is_empty() => {
-            if !markdown.ends_with('\n') {
-                markdown.push('\n');
-            }
-            Ok(markdown)
-        }
+        Some(markdown) if !markdown.trim().is_empty() => Ok(terminated(markdown)),
         _ => Err(ConvertError::Unsupported(format!(
             "PDF has no extractable text ({:?}, {} pages)",
             result.pdf_type, result.page_count
         ))),
     }
+}
+
+pub fn to_markdown_pages(bytes: &[u8]) -> Result<Vec<Page>, ConvertError> {
+    let result = pdf_inspector::extract_pages_markdown_mem(bytes, None).map_err(map_error)?;
+    Ok(result
+        .pages
+        .into_iter()
+        .map(|page| Page {
+            number: page.page + 1,
+            markdown: if page.markdown.is_empty() {
+                page.markdown
+            } else {
+                terminated(page.markdown)
+            },
+            needs_ocr: page.needs_ocr,
+        })
+        .collect())
+}
+
+fn terminated(mut markdown: String) -> String {
+    if !markdown.ends_with('\n') {
+        markdown.push('\n');
+    }
+    markdown
 }
 
 fn map_error(e: PdfError) -> ConvertError {

--- a/src/formats/pdf.rs
+++ b/src/formats/pdf.rs
@@ -2,9 +2,10 @@
 //!
 //! Unlike the other frontends, pdf-inspector emits Markdown itself, so PDFs
 //! bypass the document model and the shared GFM writer. OCR is out of scope
-//! here: a document with scanned or image-only pages errors naming them,
-//! whether that is every page or one of a hundred, because output missing
-//! those pages would read as complete.
+//! here. Whole-document conversion of a PDF with scanned or image-only pages
+//! errors naming them, whether that is every page or one of a hundred,
+//! because output missing those pages would read as complete; per-page
+//! output keeps the text pages and marks the rest instead.
 //!
 //! [pdf-inspector]: https://github.com/firecrawl/pdf-inspector
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,33 @@ pub fn to_document(
     formats::parse(bytes, resolve_format(bytes, format.into())?)
 }
 
+/// One page of a PDF, from [`to_markdown_pages`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Page {
+    /// 1-indexed page number.
+    pub number: u32,
+    /// What could be extracted from the page: unreliable or empty when it
+    /// needs OCR.
+    pub markdown: String,
+    /// The page is scanned or image-only and needs OCR, which anydoc does
+    /// not do.
+    pub needs_ocr: bool,
+}
+
+/// Convert a PDF to Markdown one page at a time, marking the pages that need
+/// OCR instead of failing the document: for attributing output to its page,
+/// and for taking the text pages of a partly scanned document.
+///
+/// Unsupported for every other format, which has no pages to speak of.
+pub fn to_markdown_pages(bytes: &[u8]) -> Result<Vec<Page>, ConvertError> {
+    match Format::from_bytes(bytes) {
+        Some(Format::Pdf) => formats::pdf::to_markdown_pages(bytes),
+        _ => Err(ConvertError::Unsupported(
+            "per-page output is for PDFs; use to_markdown_bytes".into(),
+        )),
+    }
+}
+
 fn resolve_format(bytes: &[u8], format: Option<Format>) -> Result<Format, ConvertError> {
     format.or_else(|| Format::from_bytes(bytes)).ok_or_else(|| {
         ConvertError::Unsupported("unrecognized file content: name the format explicitly".into())

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -127,6 +127,17 @@ fn scanned_pages_are_reported_not_dropped() {
     }
 }
 
+/// Per-page output keeps the text pages of a partly scanned document and
+/// marks the rest, where the whole-document conversion fails.
+#[test]
+fn pdf_pages_come_out_one_per_page() {
+    let mixed = std::fs::read(fixture_root().join("pdf/handmade-mixed.pdf")).unwrap();
+    let pages = anydoc::to_markdown_pages(&mixed).unwrap();
+    let flags: Vec<_> = pages.iter().map(|page| (page.number, page.needs_ocr)).collect();
+    assert_eq!(flags, [(1, false), (2, true)]);
+    assert!(pages[0].markdown.contains("Text on the first page"));
+}
+
 /// Embedded object payloads land in `Document::assets` with their identity
 /// and media type (the Markdown output shows only the alt text).
 #[test]

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -12,6 +12,7 @@ npm install @firecrawl/anydoc-wasm
 import init, {
   formatFromBytes,
   toMarkdownBytes,
+  toMarkdownPages,
   toDocument,
 } from '@firecrawl/anydoc-wasm';
 
@@ -25,6 +26,9 @@ const fromCsv = toMarkdownBytes(bytes, 'csv');
 
 // Or stop at the document model, which also carries embedded assets:
 const document = toDocument(bytes);
+
+// A PDF can also come out one page at a time, marking the pages that need OCR:
+const pages = toMarkdownPages(bytes);
 
 // Format detection on its own:
 formatFromBytes(bytes); // 'docx', or undefined when nothing matches

--- a/wasm/src/document.rs
+++ b/wasm/src/document.rs
@@ -5,6 +5,21 @@ use serde::Serialize;
 
 use anydoc::model;
 
+/// One page of a PDF, from `toMarkdownPages`.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Page {
+    pub number: u32,
+    pub markdown: String,
+    pub needs_ocr: bool,
+}
+
+impl From<anydoc::Page> for Page {
+    fn from(page: anydoc::Page) -> Self {
+        Page { number: page.number, markdown: page.markdown, needs_ocr: page.needs_ocr }
+    }
+}
+
 #[derive(Serialize)]
 pub struct Document {
     pub blocks: Vec<Block>,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -119,6 +119,24 @@ pub fn to_document(bytes: &[u8], format: Option<Format>) -> Result<JsValue, JsVa
         .map_err(|error| js_sys::Error::new(&error.to_string()).into())
 }
 
+/// Convert a PDF to Markdown one page at a time, marking the pages that need
+/// OCR instead of throwing for the document: for attributing output to its
+/// page, and for taking the text pages of a partly scanned document.
+///
+/// Unsupported for every other format.
+///
+/// Throws an `Error` carrying a `ConvertErrorCode` on `code`.
+#[wasm_bindgen(js_name = toMarkdownPages, unchecked_return_type = "Page[]")]
+pub fn to_markdown_pages(bytes: &[u8]) -> Result<JsValue, JsValue> {
+    let pages: Vec<Page> = anydoc::to_markdown_pages(bytes)
+        .map_err(convert_error)?
+        .into_iter()
+        .map(Page::from)
+        .collect();
+    serde_wasm_bindgen::to_value(&pages)
+        .map_err(|error| js_sys::Error::new(&error.to_string()).into())
+}
+
 /// The thrown value: a JS `Error` carrying the crate's message, with the
 /// variant name on `code` for callers to branch on, and for `needsOcr` the
 /// pages behind it.

--- a/wasm/src/typescript.rs
+++ b/wasm/src/typescript.rs
@@ -41,6 +41,19 @@ export interface NeedsOcrError extends Error {
   pageCount: number
 }
 
+/** One page of a PDF, from `toMarkdownPages`. */
+export interface Page {
+  /** 1-indexed page number. */
+  number: number
+  /**
+   * What could be extracted from the page: unreliable or empty when it
+   * needs OCR.
+   */
+  markdown: string
+  /** The page is scanned or image-only and needs OCR, which anydoc does not do. */
+  needsOcr: boolean
+}
+
 export interface Document {
   blocks: Array<Block>
   /**

--- a/wasm/test.mjs
+++ b/wasm/test.mjs
@@ -12,6 +12,7 @@ import {
   formatFromPath,
   toDocument,
   toMarkdownBytes,
+  toMarkdownPages,
 } from './pkg/anydoc_wasm.js'
 
 const fixture = (name) => fileURLToPath(new URL(`../tests/fixtures/${name}`, import.meta.url))
@@ -40,6 +41,12 @@ test('toMarkdownBytes detects the format when none is named', () => {
 test('pdf converts to Markdown but has no document model', () => {
   assert.ok(toMarkdownBytes(PDF).length > 0)
   assert.throws(() => toDocument(PDF), /pdf/i)
+})
+
+test('toMarkdownPages keeps the text pages of a partly scanned pdf', () => {
+  const pages = toMarkdownPages(MIXED)
+  assert.deepEqual(pages.map((page) => [page.number, page.needsOcr]), [[1, false], [2, true]])
+  assert.match(pages[0].markdown, /Text on the first page/)
 })
 
 test('toDocument exposes the document model', () => {


### PR DESCRIPTION
PDF output was one flat string with no page boundaries (#62, #99), and after #133 a partly scanned document fails outright.

`to_markdown_pages` returns one `Page` per physical page with its number, its Markdown, and `needs_ocr`, so a caller can attribute output to a page and keep the text pages of a partly scanned document. Same shape in Node (`toMarkdownPages`), Python and wasm.

Non-PDF input is `unsupported`. Stacked on #133.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-page Markdown output for PDFs so callers can attribute text to pages and keep text pages from partly scanned documents. Whole-document conversion is unchanged: mixed PDFs still reject; use the new per-page API to handle them.

- API: Node `toMarkdownPages(bytes): Promise<Page[]>` in `@firecrawl/anydoc` (+ TS `Page`), Python `to_markdown_pages(data) -> list[Page]` (+ `Page`), and WASM `toMarkdownPages(bytes)` in `@firecrawl/anydoc-wasm` (+ TS `Page`).
- Behavior: Each `Page` has `number` (1-indexed), `markdown` (newline-terminated when non-empty), and `needsOcr`. Non-PDF input is unsupported.
- Scope: No changes to `toMarkdown`, `toMarkdownBytes`, or `toDocument` (PDF still has no document-model form). Docs and tests updated.
- Review: Core logic in `src/formats/pdf.rs` and `src/lib.rs`; bindings map `anydoc::Page` to host-language types. Node export wired in `node/index.js`.

<sup>Written for commit fa2cc762267f3f7079f79fe66c19187d365cdfca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

