### PR TITLE
feat(node): send pages that need ocr to firecrawl parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The [skill](skills/convert-documents-to-markdown/SKILL.md) teaches the agent to 
 npx @firecrawl/anydoc report.docx               # Markdown to stdout
 npx @firecrawl/anydoc slides.pptx -o slides.md  # or to a file
 npx @firecrawl/anydoc - --format csv < data.csv # read stdin
+npx -p firecrawl -p @firecrawl/anydoc anydoc scan.pdf --ocr hosted  # scanned pages via Firecrawl Parse
 ```
 
 `npx` downloads the prebuilt binary for your platform on first run. For a permanent `anydoc` command, install globally with `npm install -g @firecrawl/anydoc`. Run `anydoc --help` for all options.

--- a/node/README.md
+++ b/node/README.md
@@ -57,6 +57,16 @@ const document = await toDocument(bytes);
 const pages = await toMarkdownPages(bytes);
 ```
 
+## Scanned pages
+
+anydoc does not do OCR: a PDF with scanned or image-only pages rejects with `needsOcr` naming them. Pass `ocr: 'hosted'` to send such a document to [Firecrawl Parse](https://firecrawl.dev/parse) instead, through the [`firecrawl`](https://www.npmjs.com/package/firecrawl) package (`npm install firecrawl`). The key comes from `apiKey` or `FIRECRAWL_API_KEY`; without one the keyless tier applies, rate-limited per IP. Documents anydoc converts itself never leave the machine.
+
+```js
+const markdown = await toMarkdown('scan.pdf', { ocr: 'hosted' });
+```
+
+On the CLI, `anydoc scan.pdf --ocr hosted`, with `--api-key` or `FIRECRAWL_API_KEY`.
+
 ## Errors
 
 A conversion rejects only when no meaningful Markdown could come out of the file. The rejection is an `Error` whose `code` names what went wrong:

--- a/node/anydoc.d.ts
+++ b/node/anydoc.d.ts
@@ -1,0 +1,41 @@
+export * from './index.js'
+import type { Format } from './index.js'
+
+/** What happens to a PDF whose pages need OCR. */
+export interface ConvertOptions {
+  /**
+   * `reject` (the default) rejects with `needsOcr` naming the pages.
+   * `hosted` sends the document to Firecrawl Parse instead, through the
+   * `firecrawl` package (an optional peer dependency). Documents anydoc
+   * converts itself never leave the machine.
+   */
+  ocr?: 'reject' | 'hosted'
+  /**
+   * Firecrawl API key for `hosted`, else `FIRECRAWL_API_KEY`; without either
+   * the keyless tier applies, rate-limited per IP.
+   */
+  apiKey?: string
+}
+
+/**
+ * Convert a document file to Markdown. The format is detected from the file
+ * content; the extension is the fallback for signature-less formats (CSV)
+ * and unrecognizable containers.
+ *
+ * Rejects with an `Error` carrying a `ConvertErrorCode` on `code`; a file
+ * that cannot be read is `'io'`.
+ */
+export declare function toMarkdown(path: string, options?: ConvertOptions): Promise<string>
+
+/**
+ * Convert an in-memory document to Markdown. Without a format, it is
+ * detected from the content, which signature-less formats (CSV) have to name
+ * explicitly.
+ *
+ * Rejects with an `Error` carrying a `ConvertErrorCode` on `code`.
+ */
+export declare function toMarkdownBytes(
+  bytes: Uint8Array,
+  format?: Format | null,
+  options?: ConvertOptions,
+): Promise<string>

--- a/node/anydoc.js
+++ b/node/anydoc.js
@@ -1,0 +1,98 @@
+'use strict'
+
+const { readFile } = require('node:fs/promises')
+const { basename } = require('node:path')
+
+const native = require('./index.js')
+const { version } = require('./package.json')
+
+/**
+ * Convert a document file to Markdown, with `options.ocr` deciding what
+ * happens to a PDF whose pages need OCR: `'reject'` (the default) rejects
+ * with `needsOcr`, `'hosted'` sends it to Firecrawl Parse instead.
+ */
+async function toMarkdown(path, options) {
+  try {
+    return await native.toMarkdown(path)
+  } catch (error) {
+    if (!sendsToHosted(error, options)) throw error
+    return parseHosted(await readFile(path), basename(path), options)
+  }
+}
+
+/** `toMarkdown` for bytes; see it for `options`. */
+async function toMarkdownBytes(bytes, format, options) {
+  try {
+    return await native.toMarkdownBytes(bytes, format)
+  } catch (error) {
+    if (!sendsToHosted(error, options)) throw error
+    return parseHosted(bytes, 'document.pdf', options)
+  }
+}
+
+function sendsToHosted(error, options) {
+  return error.code === 'needsOcr' && options?.ocr === 'hosted'
+}
+
+// The document goes through the firecrawl SDK, an optional peer dependency:
+// key handling, the keyless tier and retries are its business, not ours.
+async function parseHosted(bytes, filename, options) {
+  let Firecrawl
+  try {
+    ;({ Firecrawl } = await import('firecrawl'))
+  } catch (error) {
+    if (error.code !== 'ERR_MODULE_NOT_FOUND') throw error
+    throw hostedError("install the firecrawl package to use ocr: 'hosted'", error)
+  }
+  const keyed = Boolean(options.apiKey || process.env.FIRECRAWL_API_KEY)
+  const client = new Firecrawl({ apiKey: options.apiKey })
+  let document
+  try {
+    document = await client.parse(
+      { data: bytes, filename, contentType: 'application/pdf' },
+      { parsers: [{ type: 'pdf', mode: 'auto' }], timeout: 300000, origin: `anydoc@${version}` },
+    )
+  } catch (error) {
+    throw hostedError(describe(error, keyed), error)
+  }
+  return document.markdown ?? ''
+}
+
+function describe(error, keyed) {
+  switch (error.status) {
+    case 401:
+      return `Firecrawl Parse rejected the API key: ${error.message}`
+    case 402:
+      return `Firecrawl Parse is out of credits: ${error.message}`
+    case 429:
+      return keyed
+        ? `Firecrawl Parse rate limit reached: ${error.message}`
+        : `Firecrawl Parse keyless limit reached, set FIRECRAWL_API_KEY: ${error.message}`
+    default:
+      return `Firecrawl Parse: ${error.message}`
+  }
+}
+
+function hostedError(message, cause) {
+  const error = new Error(message, { cause })
+  error.code = 'hosted'
+  return error
+}
+
+// Spelled out so ESM `import { ... }` sees the names.
+module.exports.BlockKind = native.BlockKind
+module.exports.CellSlotKind = native.CellSlotKind
+module.exports.Format = native.Format
+module.exports.formatFromBytes = native.formatFromBytes
+module.exports.formatFromExtension = native.formatFromExtension
+module.exports.formatFromPath = native.formatFromPath
+module.exports.ImageSourceKind = native.ImageSourceKind
+module.exports.InlineKind = native.InlineKind
+module.exports.LinkTargetKind = native.LinkTargetKind
+module.exports.MarkerKind = native.MarkerKind
+module.exports.NoteKind = native.NoteKind
+module.exports.TableKind = native.TableKind
+module.exports.toDocument = native.toDocument
+module.exports.toMarkdownPages = native.toMarkdownPages
+module.exports.toMarkdown = toMarkdown
+module.exports.toMarkdownBytes = toMarkdownBytes

--- a/node/cli.js
+++ b/node/cli.js
@@ -21,13 +21,21 @@ Options:
                          ${FORMATS}
                          (extension aliases like xls, docm, ppsx resolve
                          to these)
+  --ocr <mode>           What to do with a PDF whose pages need OCR:
+                         reject (default) exits 3 naming them; hosted sends
+                         the document to Firecrawl Parse through the
+                         firecrawl package, which must be installed
+  --api-key <key>        Firecrawl API key for --ocr hosted, else
+                         FIRECRAWL_API_KEY; without either the keyless
+                         tier applies, rate-limited per IP
   -h, --help             Print this help and exit
   -V, --version          Print the version and exit
 
 The format is detected from the file content; the file extension is the
 fallback for signature-less formats (CSV). stdin has no extension, so CSV
 input from stdin needs --format csv. Scanned or image-only pages need OCR,
-which anydoc does not do: the document exits 3 naming them.
+which anydoc does not do: the document exits 3 naming them, or goes to
+Firecrawl Parse with --ocr hosted.
 
 Exit codes:
   0  success
@@ -40,7 +48,10 @@ Examples:
   anydoc slides.pptx -o slides.md
   anydoc - --format csv < data.csv
   curl -s https://example.com/paper.pdf | anydoc -
+  anydoc scan.pdf --ocr hosted
 `
+
+const OCR_MODES = ['reject', 'hosted']
 
 const USAGE_ERROR = 2
 const CONVERSION_ERROR = 1
@@ -52,7 +63,7 @@ function fail(code, message) {
 }
 
 function parseArgs(argv) {
-  const args = { input: null, output: null, format: null }
+  const args = { input: null, output: null, format: null, ocr: null, apiKey: null }
   let positionalOnly = false
   for (let i = 0; i < argv.length; i++) {
     let arg = argv[i]
@@ -97,6 +108,15 @@ function parseArgs(argv) {
       case '--format':
         args.format = value()
         break
+      case '--ocr':
+        args.ocr = value()
+        if (!OCR_MODES.includes(args.ocr)) {
+          fail(USAGE_ERROR, `invalid --ocr '${args.ocr}'; expected one of: ${OCR_MODES.join(', ')}`)
+        }
+        break
+      case '--api-key':
+        args.apiKey = value()
+        break
       default:
         fail(USAGE_ERROR, `unknown option '${arg}' (see anydoc --help)`)
     }
@@ -123,7 +143,7 @@ async function main() {
 
   // Loaded after argument handling so --help and --version work even where
   // no native binding is available.
-  const { formatFromExtension, toMarkdown, toMarkdownBytes } = require('./index.js')
+  const { formatFromExtension, toMarkdown, toMarkdownBytes } = require('./anydoc.js')
 
   let format
   if (args.format !== null) {
@@ -133,14 +153,15 @@ async function main() {
     }
   }
 
+  const options = { ocr: args.ocr ?? undefined, apiKey: args.apiKey ?? undefined }
   let markdown
   try {
     if (args.input === '-') {
-      markdown = await toMarkdownBytes(await readStdin(), format)
+      markdown = await toMarkdownBytes(await readStdin(), format, options)
     } else if (format !== undefined) {
-      markdown = await toMarkdownBytes(await readFile(args.input), format)
+      markdown = await toMarkdownBytes(await readFile(args.input), format, options)
     } else {
-      markdown = await toMarkdown(args.input)
+      markdown = await toMarkdown(args.input, options)
     }
   } catch (error) {
     fail(error.code === 'needsOcr' ? NEEDS_OCR : CONVERSION_ERROR, error.message)

--- a/node/dts-header.d.ts
+++ b/node/dts-header.d.ts
@@ -23,6 +23,8 @@ export type ConvertErrorCode =
   | 'missingPart'
   /** The file could not be read, from `toMarkdown` only. */
   | 'io'
+  /** `ocr: 'hosted'` could not get the document through Firecrawl Parse. */
+  | 'hosted'
 
 /** The rejection for a PDF with pages that need OCR. */
 export interface NeedsOcrError extends Error {

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -23,6 +23,8 @@ export type ConvertErrorCode =
   | 'missingPart'
   /** The file could not be read, from `toMarkdown` only. */
   | 'io'
+  /** `ocr: 'hosted'` could not get the document through Firecrawl Parse. */
+  | 'hosted'
 
 /** The rejection for a PDF with pages that need OCR. */
 export interface NeedsOcrError extends Error {

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -12,7 +12,8 @@
         "anydoc": "cli.js"
       },
       "devDependencies": {
-        "@napi-rs/cli": "^3.8.2"
+        "@napi-rs/cli": "^3.8.2",
+        "firecrawl": "^4.35.0"
       },
       "engines": {
         "node": ">= 20"
@@ -1675,6 +1676,19 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1682,12 +1696,46 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/chardet": {
       "version": "2.2.0",
@@ -1729,6 +1777,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
@@ -1761,6 +1822,31 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/emnapi": {
       "version": "2.0.0-alpha.3",
       "resolved": "https://registry.npmjs.org/emnapi/-/emnapi-2.0.0-alpha.3.tgz",
@@ -1774,6 +1860,55 @@
         "node-addon-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-toolkit": {
@@ -1813,6 +1948,178 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/firecrawl": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/firecrawl/-/firecrawl-4.35.0.tgz",
+      "integrity": "sha512-XbW9Gqg++eAq49QcPJDHMKlRbbebmpImEpa5i6N9K+aIn9oIAwHxO4Kk4bxdoYSa8tRnPJrj3x86z/bBstFgHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "1.18.0",
+        "typescript-event-target": "^1.1.1",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -1862,6 +2169,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1891,6 +2231,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -1958,12 +2308,39 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-event-target": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.2.tgz",
+      "integrity": "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/node/package.json
+++ b/node/package.json
@@ -22,12 +22,14 @@
     "converter",
     "document"
   ],
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "anydoc.js",
+  "types": "anydoc.d.ts",
   "bin": {
     "anydoc": "cli.js"
   },
   "files": [
+    "anydoc.js",
+    "anydoc.d.ts",
     "index.js",
     "index.d.ts",
     "cli.js",
@@ -58,7 +60,16 @@
     "test": "node --test",
     "version": "napi version"
   },
+  "peerDependencies": {
+    "firecrawl": ">=4"
+  },
+  "peerDependenciesMeta": {
+    "firecrawl": {
+      "optional": true
+    }
+  },
   "devDependencies": {
-    "@napi-rs/cli": "^3.8.2"
+    "@napi-rs/cli": "^3.8.2",
+    "firecrawl": "^4.35.0"
   }
 }

--- a/node/test.mjs
+++ b/node/test.mjs
@@ -2,6 +2,7 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -16,7 +17,7 @@ import {
   toMarkdown,
   toMarkdownBytes,
   toMarkdownPages,
-} from './index.js'
+} from './anydoc.js'
 
 const fixture = (name) => fileURLToPath(new URL(`../tests/fixtures/${name}`, import.meta.url))
 
@@ -101,6 +102,60 @@ test('toMarkdownPages keeps the text pages of a partly scanned pdf', async () =>
   assert.match(pages[0].markdown, /Text on the first page/)
 })
 
+test('the package exports everything the native binding does', async () => {
+  const [wrapper, native] = await Promise.all([import('./anydoc.js'), import('./index.js')])
+  assert.deepEqual(Object.keys(wrapper).sort(), Object.keys(native).sort())
+})
+
+// A stand-in for api.firecrawl.dev that answers every request with `reply`
+// and records the paths hit. Runs `run` keyless, whatever the environment.
+async function withHostedStub(reply, run) {
+  const hits = []
+  const server = createServer((request, response) => {
+    hits.push(request.url)
+    request.resume().on('end', () => {
+      response.writeHead(reply.status, { 'content-type': 'application/json' })
+      response.end(JSON.stringify(reply.body))
+    })
+  })
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const url = `http://127.0.0.1:${server.address().port}`
+  const saved = { FIRECRAWL_API_URL: process.env.FIRECRAWL_API_URL, FIRECRAWL_API_KEY: process.env.FIRECRAWL_API_KEY }
+  process.env.FIRECRAWL_API_URL = url
+  delete process.env.FIRECRAWL_API_KEY
+  try {
+    await run(hits, url)
+  } finally {
+    for (const [name, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+    server.close()
+  }
+}
+
+const HOSTED = { status: 200, body: { success: true, data: { markdown: '# Read by the hosted parser\n' } } }
+
+test("ocr: 'hosted' sends a pdf with scanned pages to Firecrawl Parse, and nothing else", async () => {
+  await withHostedStub(HOSTED, async (hits) => {
+    assert.equal(await toMarkdown(MIXED, { ocr: 'hosted' }), HOSTED.body.data.markdown)
+    assert.deepEqual(hits, ['/v2/parse'])
+    assert.match(await toMarkdown(OUTLINE, { ocr: 'hosted' }), /^# /m)
+    assert.deepEqual(hits, ['/v2/parse'])
+  })
+})
+
+test('the keyless limit says to set an api key', async () => {
+  const limited = { status: 429, body: { success: false, error: 'Rate limit exceeded' } }
+  await withHostedStub(limited, async () => {
+    await assert.rejects(toMarkdown(MIXED, { ocr: 'hosted' }), (error) => {
+      assert.equal(error.code, 'hosted')
+      assert.match(error.message, /set FIRECRAWL_API_KEY/)
+      return true
+    })
+  })
+})
+
 const CLI = fileURLToPath(new URL('./cli.js', import.meta.url))
 
 // execFile rejects on a non-zero exit; the error carries code/stdout/stderr.
@@ -146,8 +201,17 @@ test('cli exits 3 when pages need OCR', async () => {
   assert.match(stderr, /^anydoc: 1 of 2 pages need OCR/)
 })
 
+test('cli --ocr hosted converts a pdf with scanned pages through Firecrawl Parse', async () => {
+  await withHostedStub(HOSTED, async (hits, url) => {
+    const env = { ...process.env, FIRECRAWL_API_URL: url }
+    const { code, stdout } = await runCli([MIXED, '--ocr', 'hosted'], { env })
+    assert.equal(code, undefined)
+    assert.equal(stdout, HOSTED.body.data.markdown)
+  })
+})
+
 test('cli exits 2 on usage errors', async () => {
-  for (const args of [[], ['--frmat', 'csv', CSV], ['--format', 'nope', CSV], [OUTLINE, RICH]]) {
+  for (const args of [[], ['--frmat', 'csv', CSV], ['--format', 'nope', CSV], [OUTLINE, RICH], ['--ocr', 'cloud', MIXED]]) {
     const { code, stderr } = await runCli(args)
     assert.equal(code, 2)
     assert.match(stderr, /^anydoc: /)

--- a/skills/convert-documents-to-markdown/SKILL.md
+++ b/skills/convert-documents-to-markdown/SKILL.md
@@ -22,5 +22,5 @@ Rules:
 2. The format is detected from the file content. Pass `--format <name>` only when detection cannot work: CSV from stdin, or a missing or wrong extension.
 3. Exit codes: 0 success, 1 the document could not be converted, 2 usage error. Failures print one `anydoc: <message>` line to stderr. The CLI never prompts.
 4. For a large document, write to a file with `-o` and read the parts you need instead of streaming everything into context.
-5. Scanned and image-only pages need OCR, which anydoc does not do; the document exits 3 and the message names the pages. The hosted [Firecrawl Parse](https://firecrawl.dev/parse) API handles those.
+5. Scanned and image-only pages need OCR, which anydoc does not do; the document exits 3 and the message names the pages. Rerun with `--ocr hosted` to send it to [Firecrawl Parse](https://firecrawl.dev/parse), which needs the `firecrawl` package alongside: `npx -y -p firecrawl -p @firecrawl/anydoc anydoc <file> --ocr hosted`. That works without a key up to the keyless limit; past it, set `FIRECRAWL_API_KEY`.
 6. Inside a Node, Python, or Rust codebase, prefer the library over shelling out: `@firecrawl/anydoc` on npm, `firecrawl-anydoc` on PyPI, `anydoc` on crates.io. Each exposes the same `to_markdown` / `toMarkdown` API.


### PR DESCRIPTION
A PDF with scanned pages is a dead end from the Node package and the CLI: `needsOcr` and nothing to do with it.

`toMarkdown` and `toMarkdownBytes` take `{ ocr: 'hosted' }` (CLI: `--ocr hosted`), which hands a document that fails with `needsOcr`, and only that, to Firecrawl Parse through the `firecrawl` SDK as an optional peer dependency. Key from `apiKey` / `--api-key` or `FIRECRAWL_API_KEY`, keyless tier otherwise; failures come back as `hosted` with the keyless limit pointing at the env var. The package entry moves to `anydoc.js`, a wrapper over the generated `index.js`, with an export-parity test so the two cannot drift.

Tests run against a local stub of `/v2/parse`; nothing touches the network. Stacked on #134.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route PDFs with scanned pages to Firecrawl Parse on demand. Previously these failed with `needsOcr`; now `ocr: 'hosted'` (or `--ocr hosted`) sends only those documents to the hosted parser, while all other files still convert locally.

- Node: `toMarkdown`/`toMarkdownBytes` accept `{ ocr: 'reject' | 'hosted', apiKey? }`; reads `FIRECRAWL_API_KEY` if `apiKey` is unset. Hosted-path failures surface as error code `hosted`.
- CLI: adds `--ocr hosted` and `--api-key`; falls back to `FIRECRAWL_API_KEY`. Keyless tier applies without a key; exit codes unchanged (PDF pages needing OCR still exit 3).
- Dependency: hosted OCR requires optional peer `firecrawl` (install to use hosted OCR). No network calls unless a document actually hits `needsOcr`; missing SDK errors as `hosted`.
- Packaging: switch `main`/`types` to `anydoc.js`/`anydoc.d.ts`, a wrapper around the native `index.js`; CLI imports the wrapper; a test enforces export parity.
- Docs/Tests: README and skill docs show `npx -p firecrawl -p @firecrawl/anydoc anydoc scan.pdf --ocr hosted`; tests stub `/v2/parse`, avoid real network, and verify only `needsOcr` cases call the hosted path and keyless 429 messaging.

<sup>Written for commit b414bb04b2b22b1f578bca6946a2285407f054dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

