### PR TITLE
feat(python): send pages that need ocr to firecrawl parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
       - run: pip install maturin
       - run: maturin build --release --locked --manifest-path python/Cargo.toml --out dist
       - run: pip install --no-index --find-links dist firecrawl-anydoc
+      - run: pip install firecrawl
       # Must run from the repo root: with python/ as cwd, the source anydoc/
       # package dir shadows the installed compiled module.
       - run: python -m unittest discover -s python/tests

--- a/python/README.md
+++ b/python/README.md
@@ -47,6 +47,14 @@ document = anydoc.to_document(data)
 pages = anydoc.to_markdown_pages(data)
 ```
 
+## Scanned pages
+
+anydoc does not do OCR: a PDF with scanned or image-only pages raises `NeedsOcrError` naming them. Pass `ocr="hosted"` to send such a document to [Firecrawl Parse](https://firecrawl.dev/parse) instead, through the [`firecrawl`](https://pypi.org/project/firecrawl/) package (`pip install 'firecrawl-anydoc[hosted]'`). The key comes from `api_key` or `FIRECRAWL_API_KEY`; without one the keyless tier applies, rate-limited per IP. Documents anydoc converts itself never leave the machine.
+
+```python
+markdown = anydoc.to_markdown("scan.pdf", ocr="hosted")
+```
+
 ## Errors
 
 A conversion raises only when no meaningful Markdown could come out of the file. The exception type names what went wrong:

--- a/python/anydoc/__init__.py
+++ b/python/anydoc/__init__.py
@@ -1,5 +1,7 @@
 """Convert documents to GitHub-Flavored Markdown."""
 
+import os
+from pathlib import Path
 from typing import Literal
 
 from anydoc._anydoc import (
@@ -28,10 +30,10 @@ from anydoc._anydoc import (
     format_from_extension,
     format_from_path,
     to_document,
-    to_markdown,
-    to_markdown_bytes,
     to_markdown_pages,
 )
+from anydoc._anydoc import to_markdown as _to_markdown
+from anydoc._anydoc import to_markdown_bytes as _to_markdown_bytes
 
 Format = Literal[
     "doc", "docx", "odt", "pdf", "ppt", "pptx", "rtf", "epub", "xlsx", "ods", "odp", "csv"
@@ -39,6 +41,93 @@ Format = Literal[
 """Input format, named after the extension that identifies it. Container
 variants that share a parser (`.docm`, `.xlsm`, `.ppsx`, ...) map onto these
 via `format_from_bytes` or `format_from_extension`."""
+
+Ocr = Literal["reject", "hosted"]
+"""What happens to a PDF whose pages need OCR. `reject` (the default) raises
+`NeedsOcrError` naming the pages. `hosted` sends the document to Firecrawl
+Parse instead, through the `firecrawl` package
+(`pip install 'firecrawl-anydoc[hosted]'`). Documents anydoc converts itself
+never leave the machine."""
+
+
+class HostedError(ConvertError):
+    """`ocr="hosted"` could not get the document through Firecrawl Parse."""
+
+
+def to_markdown(
+    path: "str | os.PathLike[str]", *, ocr: Ocr = "reject", api_key: "str | None" = None
+) -> str:
+    """Convert a document file to Markdown. The format is detected from the
+    file content; the extension is the fallback for signature-less formats
+    (CSV) and unrecognizable containers.
+
+    `api_key` is the Firecrawl key for `ocr="hosted"`, else
+    `FIRECRAWL_API_KEY`; without either the keyless tier applies, rate-limited
+    per IP."""
+    try:
+        return _to_markdown(path)
+    except NeedsOcrError:
+        if ocr != "hosted":
+            raise
+    path = Path(path)
+    return _parse_hosted(path.read_bytes(), path.name, api_key)
+
+
+def to_markdown_bytes(
+    data: "bytes | bytearray",
+    format: "Format | None" = None,
+    *,
+    ocr: Ocr = "reject",
+    api_key: "str | None" = None,
+) -> str:
+    """Convert an in-memory document to Markdown. Without a format, it is
+    detected from the content, which signature-less formats (CSV) have to
+    name explicitly. `ocr` and `api_key` are as for `to_markdown`."""
+    try:
+        return _to_markdown_bytes(data, format)
+    except NeedsOcrError:
+        if ocr != "hosted":
+            raise
+    return _parse_hosted(bytes(data), "document.pdf", api_key)
+
+
+# The document goes through the firecrawl SDK, an optional extra: key
+# handling, the keyless tier and retries are its business, not ours.
+def _parse_hosted(data: bytes, filename: str, api_key: "str | None") -> str:
+    try:
+        from firecrawl import Firecrawl
+        from firecrawl.v2.types import ParseOptions, PDFParser
+    except ImportError as error:
+        raise HostedError('install firecrawl-anydoc[hosted] to use ocr="hosted"') from error
+    keyed = bool(api_key or os.environ.get("FIRECRAWL_API_KEY"))
+    client = Firecrawl(
+        api_key=api_key,
+        api_url=os.environ.get("FIRECRAWL_API_URL", "https://api.firecrawl.dev"),
+    )
+    try:
+        document = client.parse(
+            data,
+            filename=filename,
+            content_type="application/pdf",
+            options=ParseOptions(parsers=[PDFParser(mode="auto")], timeout=300000),
+        )
+    except Exception as error:
+        raise HostedError(_describe(error, keyed)) from error
+    return document.markdown or ""
+
+
+def _describe(error: Exception, keyed: bool) -> str:
+    status = getattr(error, "status_code", None)
+    if status == 401:
+        return f"Firecrawl Parse rejected the API key: {error}"
+    if status == 402:
+        return f"Firecrawl Parse is out of credits: {error}"
+    if status == 429 and keyed:
+        return f"Firecrawl Parse rate limit reached: {error}"
+    if status == 429:
+        return f"Firecrawl Parse keyless limit reached, set FIRECRAWL_API_KEY: {error}"
+    return f"Firecrawl Parse: {error}"
+
 
 __all__ = [
     "Asset",
@@ -49,6 +138,7 @@ __all__ = [
     "Document",
     "EncryptedError",
     "Format",
+    "HostedError",
     "ImageSource",
     "Inline",
     "LinkTarget",
@@ -58,6 +148,7 @@ __all__ = [
     "MissingPartError",
     "NeedsOcrError",
     "Note",
+    "Ocr",
     "Page",
     "ResourceLimitError",
     "Style",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,10 @@ classifiers = [
 # The version comes from Cargo.toml `package.version`.
 dynamic = ["version"]
 
+[project.optional-dependencies]
+# `ocr="hosted"`: pages that need OCR go to Firecrawl Parse through its SDK.
+hosted = ["firecrawl>=4"]
+
 [project.urls]
 Homepage = "https://github.com/firecrawl/anydoc#readme"
 Repository = "https://github.com/firecrawl/anydoc"

--- a/python/tests/test_anydoc.py
+++ b/python/tests/test_anydoc.py
@@ -2,8 +2,13 @@
 
 import ast
 import io
+import json
+import os
+import threading
 import unittest
 import zipfile
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import anydoc
@@ -15,6 +20,46 @@ CSV = FIXTURES / "csv" / "sheet.csv"
 ENCRYPTED = FIXTURES / "malformed" / "encrypted--errors.odt"
 ZIPBOMB = FIXTURES / "abuse" / "zipbomb--errors.docx"
 MIXED = FIXTURES / "pdf" / "handmade-mixed.pdf"
+
+
+HOSTED_MARKDOWN = "# Read by the hosted parser\n"
+
+
+@contextmanager
+def hosted_stub(status, body):
+    """A stand-in for api.firecrawl.dev that answers every request with one
+    reply and records the paths hit. The block runs keyless, whatever the
+    environment."""
+    hits = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            hits.append(self.path)
+            self.rfile.read(int(self.headers.get("content-length", 0)))
+            payload = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    saved = {name: os.environ.pop(name, None) for name in ("FIRECRAWL_API_URL", "FIRECRAWL_API_KEY")}
+    os.environ["FIRECRAWL_API_URL"] = f"http://127.0.0.1:{server.server_port}"
+    try:
+        yield hits
+    finally:
+        server.shutdown()
+        server.server_close()
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 class AnydocTest(unittest.TestCase):
@@ -94,6 +139,19 @@ class AnydocTest(unittest.TestCase):
             anydoc.to_markdown_bytes(package.getvalue(), "docx")
         self.assertEqual(caught.exception.part, "word/document.xml")
 
+    def test_ocr_hosted_sends_a_pdf_with_scanned_pages_to_firecrawl_parse_and_nothing_else(self):
+        reply = {"success": True, "data": {"markdown": HOSTED_MARKDOWN}}
+        with hosted_stub(200, reply) as hits:
+            self.assertEqual(anydoc.to_markdown(MIXED, ocr="hosted"), HOSTED_MARKDOWN)
+            self.assertEqual(hits, ["/v2/parse"])
+            self.assertRegex(anydoc.to_markdown(OUTLINE, ocr="hosted"), r"(?m)^# ")
+            self.assertEqual(hits, ["/v2/parse"])
+
+    def test_the_keyless_limit_says_to_set_an_api_key(self):
+        with hosted_stub(429, {"success": False, "error": "Rate limit exceeded"}):
+            with self.assertRaisesRegex(anydoc.HostedError, "set FIRECRAWL_API_KEY"):
+                anydoc.to_markdown_bytes(MIXED.read_bytes(), ocr="hosted")
+
     def test_unreadable_files_and_bad_arguments_raise_the_python_exception(self):
         with self.assertRaises(FileNotFoundError):
             anydoc.to_markdown("no-such-file.docx")
@@ -109,8 +167,8 @@ class AnydocTest(unittest.TestCase):
         }
         exported = {name for name in dir(anydoc._anydoc) if not name.startswith("_")}
         self.assertEqual(stubbed, exported)
-        # __init__.py re-exports the whole module, plus the Format alias.
-        self.assertEqual(set(anydoc.__all__), exported | {"Format"})
+        # __init__.py re-exports the whole module, plus what it adds itself.
+        self.assertEqual(set(anydoc.__all__), exported | {"Format", "HostedError", "Ocr"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Python side of #135: `to_markdown` and `to_markdown_bytes` take `ocr="hosted"` and `api_key`, handing a document that raises `NeedsOcrError`, and only that, to Firecrawl Parse through the `firecrawl` SDK as the `firecrawl-anydoc[hosted]` extra. Failures raise `HostedError`, with the keyless limit pointing at `FIRECRAWL_API_KEY`.

The SDK does not read `FIRECRAWL_API_URL` itself, so the wrapper passes it through for self-hosters and the test stub. CI installs `firecrawl` for the tests. Stacked on #135.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hosted OCR fallback for Python: to_markdown and to_markdown_bytes accept ocr="hosted" to send PDFs with scanned pages to Firecrawl Parse via the `firecrawl` SDK. Default behavior stays the same (raise NeedsOcrError); hosted failures raise HostedError with actionable messages.

- Sends only documents that raise NeedsOcrError; locally converted files never leave the machine.
- Exports `Ocr` ("reject" | "hosted") and `HostedError`.
- Uses `api_key` or `FIRECRAWL_API_KEY`; supports `FIRECRAWL_API_URL` for self-hosted; clear 401/402/429 messages (keyless 429 instructs setting FIRECRAWL_API_KEY).
- Optional dependency: install `firecrawl-anydoc[hosted]` (adds `firecrawl>=4`). CI installs `firecrawl` for tests; README documents usage; tests stub the API and cover error mapping.

<sup>Written for commit 2644c6f23a2ba5cd87a8bb577c5377bd1cd917ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

