### PR TITLE
feat: send a pdf that needs ocr to firecrawl parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The [skill](skills/convert-documents-to-markdown/SKILL.md) teaches the agent to 
 npx @firecrawl/anydoc report.docx               # Markdown to stdout
 npx @firecrawl/anydoc slides.pptx -o slides.md  # or to a file
 npx @firecrawl/anydoc - --format csv < data.csv # read stdin
+npx @firecrawl/anydoc scan.pdf --ocr hosted     # scanned pages via Firecrawl Parse
 ```
 
 `npx` downloads the prebuilt binary for your platform on first run. For a permanent `anydoc` command, install globally with `npm install -g @firecrawl/anydoc`. Run `anydoc --help` for all options.
@@ -231,6 +232,8 @@ match anydoc::to_markdown(path) {
 | `Io`            | The file could not be read, from `to_markdown` only                 |
 
 Node and wasm publish the variant name on `error.code`; Python raises one `anydoc.ConvertError` subclass per variant, or `OSError` when the file cannot be read.
+
+anydoc converts locally and does not do OCR, so a PDF with scanned pages fails with `NeedsOcr`. Opt in with `ocr: 'hosted'` in Node, `ocr="hosted"` in Python or `--ocr hosted` on the CLI to send that document to [Firecrawl Parse](https://firecrawl.dev/parse). No signup needed. Set `FIRECRAWL_API_KEY` for higher limits.
 
 ## How it works
 

--- a/node/README.md
+++ b/node/README.md
@@ -32,6 +32,7 @@ The package ships an `anydoc` command, so `npx` converts a document with no inst
 npx @firecrawl/anydoc report.docx               # Markdown to stdout
 npx @firecrawl/anydoc slides.pptx -o slides.md  # or to a file
 npx @firecrawl/anydoc - --format csv < data.csv # read stdin
+npx @firecrawl/anydoc scan.pdf --ocr hosted     # scanned pages via Firecrawl Parse
 ```
 
 Markdown goes to stdout, errors to stderr, and `anydoc --help` covers the rest.
@@ -53,6 +54,16 @@ const fromCsv = await toMarkdownBytes(bytes, 'csv');
 // Or stop at the document model, which also carries embedded assets:
 const document = await toDocument(bytes);
 ```
+
+## Scanned pages
+
+anydoc converts locally and does not do OCR, so a PDF with scanned or image-only pages rejects with `needsOcr`. Opt in with `ocr: 'hosted'` to send that document to [Firecrawl Parse](https://firecrawl.dev/parse). No signup needed. Set `apiKey` or `FIRECRAWL_API_KEY` for higher limits.
+
+```js
+const markdown = await toMarkdown('scan.pdf', { ocr: 'hosted' });
+```
+
+On the CLI, `anydoc scan.pdf --ocr hosted`.
 
 ## Errors
 
@@ -80,6 +91,7 @@ try {
 | `resourceLimit` | Crossed a fixed safety limit (decompression, nesting, node count)   |
 | `missingPart`   | A part required for any meaningful output is absent                 |
 | `io`            | The file could not be read, from `toMarkdown` only                  |
+| `hosted`        | `ocr: 'hosted'` could not get the document through Firecrawl Parse  |
 
 `error.message` carries the detail, naming the package part at fault where the format identifies one. TypeScript gets the union as `ConvertErrorCode`.
 

--- a/node/anydoc.d.ts
+++ b/node/anydoc.d.ts
@@ -1,0 +1,40 @@
+export * from './index.js'
+import type { Format } from './index.js'
+
+/** What happens to a PDF whose pages need OCR. */
+export interface ConvertOptions {
+  /**
+   * `reject` (the default) rejects with `needsOcr` naming the pages.
+   * `hosted` sends the whole document to Firecrawl Parse instead, keyless
+   * unless a key is given. Documents anydoc converts itself never leave the
+   * machine.
+   */
+  ocr?: 'reject' | 'hosted'
+  /** Firecrawl API key for `hosted`, else `FIRECRAWL_API_KEY`, else keyless. */
+  apiKey?: string
+  /** Firecrawl API URL for `hosted`, else `FIRECRAWL_API_URL`, else `https://api.firecrawl.dev`. */
+  apiUrl?: string
+}
+
+/**
+ * Convert a document file to Markdown. The format is detected from the file
+ * content; the extension is the fallback for signature-less formats (CSV)
+ * and unrecognizable containers.
+ *
+ * Rejects with an `Error` carrying a `ConvertErrorCode` on `code`; a file
+ * that cannot be read is `'io'`.
+ */
+export declare function toMarkdown(path: string, options?: ConvertOptions): Promise<string>
+
+/**
+ * Convert an in-memory document to Markdown. Without a format, it is
+ * detected from the content, which signature-less formats (CSV) have to name
+ * explicitly.
+ *
+ * Rejects with an `Error` carrying a `ConvertErrorCode` on `code`.
+ */
+export declare function toMarkdownBytes(
+  bytes: Uint8Array,
+  format?: Format | null,
+  options?: ConvertOptions,
+): Promise<string>

--- a/node/anydoc.js
+++ b/node/anydoc.js
@@ -52,7 +52,7 @@ async function parseHosted(bytes, filename, options) {
   let reply
   try {
     response = await fetch(url, { method: 'POST', headers, body, signal: AbortSignal.timeout(TIMEOUT_MS) })
-    reply = await response.json().catch(() => ({}))
+    reply = (await response.json().catch(() => null)) ?? {}
   } catch (error) {
     throw hostedError(`Firecrawl Parse: ${error.message}`, error)
   }
@@ -60,7 +60,7 @@ async function parseHosted(bytes, filename, options) {
     throw hostedError(describe(response.status, reply.error ?? response.statusText, Boolean(apiKey)))
   }
   const markdown = reply.data?.markdown
-  if (!markdown) throw hostedError('Firecrawl Parse returned no Markdown')
+  if (typeof markdown !== 'string' || !markdown) throw hostedError('Firecrawl Parse returned no Markdown')
   return markdown.endsWith('\n') ? markdown : `${markdown}\n`
 }
 

--- a/node/anydoc.js
+++ b/node/anydoc.js
@@ -1,0 +1,103 @@
+'use strict'
+
+const { readFile } = require('node:fs/promises')
+const { basename } = require('node:path')
+
+const native = require('./index.js')
+const { version } = require('./package.json')
+
+const API_URL = 'https://api.firecrawl.dev'
+const TIMEOUT_MS = 300_000
+
+/**
+ * Convert a document file to Markdown. `options.ocr` decides what happens to
+ * a PDF whose pages need OCR: `'reject'` (the default) rejects with
+ * `needsOcr`, `'hosted'` sends the document to Firecrawl Parse instead.
+ */
+async function toMarkdown(path, options) {
+  try {
+    return await native.toMarkdown(path)
+  } catch (error) {
+    if (!sendsToHosted(error, options)) throw error
+    return parseHosted(await readFile(path), basename(path), options)
+  }
+}
+
+/** `toMarkdown` for bytes; `options` as there. */
+async function toMarkdownBytes(bytes, format, options) {
+  try {
+    return await native.toMarkdownBytes(bytes, format)
+  } catch (error) {
+    if (!sendsToHosted(error, options)) throw error
+    return parseHosted(bytes, 'document.pdf', options)
+  }
+}
+
+function sendsToHosted(error, options) {
+  return error.code === 'needsOcr' && options?.ocr === 'hosted'
+}
+
+// The whole document goes, not only the pages that need OCR: Parse has no
+// page selection.
+async function parseHosted(bytes, filename, options) {
+  const apiKey = options.apiKey ?? process.env.FIRECRAWL_API_KEY
+  const apiUrl = options.apiUrl ?? process.env.FIRECRAWL_API_URL ?? API_URL
+  const url = `${apiUrl.replace(/\/$/, '')}/v2/parse`
+  const parse = { parsers: [{ type: 'pdf', mode: 'auto' }], origin: `anydoc@${version}` }
+  const body = new FormData()
+  body.append('options', JSON.stringify(parse))
+  body.append('file', new Blob([bytes], { type: 'application/pdf' }), filename)
+  const headers = apiKey ? { authorization: `Bearer ${apiKey}` } : {}
+  let response
+  let reply
+  try {
+    response = await fetch(url, { method: 'POST', headers, body, signal: AbortSignal.timeout(TIMEOUT_MS) })
+    reply = await response.json().catch(() => ({}))
+  } catch (error) {
+    throw hostedError(`Firecrawl Parse: ${error.message}`, error)
+  }
+  if (!response.ok || !reply.success) {
+    throw hostedError(describe(response.status, reply.error ?? response.statusText, Boolean(apiKey)))
+  }
+  const markdown = reply.data?.markdown
+  if (!markdown) throw hostedError('Firecrawl Parse returned no Markdown')
+  return markdown.endsWith('\n') ? markdown : `${markdown}\n`
+}
+
+function describe(status, detail, keyed) {
+  switch (status) {
+    case 401:
+      return `Firecrawl Parse rejected the API key: ${detail}`
+    case 402:
+      return `Firecrawl Parse is out of credits: ${detail}`
+    case 429:
+      return keyed
+        ? `Firecrawl Parse rate limit reached: ${detail}`
+        : `Firecrawl Parse keyless limit reached, set FIRECRAWL_API_KEY: ${detail}`
+    default:
+      return `Firecrawl Parse: ${detail}`
+  }
+}
+
+function hostedError(message, cause) {
+  const error = cause === undefined ? new Error(message) : new Error(message, { cause })
+  error.code = 'hosted'
+  return error
+}
+
+// Spelled out so ESM `import { ... }` sees the names.
+module.exports.BlockKind = native.BlockKind
+module.exports.CellSlotKind = native.CellSlotKind
+module.exports.Format = native.Format
+module.exports.formatFromBytes = native.formatFromBytes
+module.exports.formatFromExtension = native.formatFromExtension
+module.exports.formatFromPath = native.formatFromPath
+module.exports.ImageSourceKind = native.ImageSourceKind
+module.exports.InlineKind = native.InlineKind
+module.exports.LinkTargetKind = native.LinkTargetKind
+module.exports.MarkerKind = native.MarkerKind
+module.exports.NoteKind = native.NoteKind
+module.exports.TableKind = native.TableKind
+module.exports.toDocument = native.toDocument
+module.exports.toMarkdown = toMarkdown
+module.exports.toMarkdownBytes = toMarkdownBytes

--- a/node/cli.js
+++ b/node/cli.js
@@ -21,13 +21,21 @@ Options:
                          ${FORMATS}
                          (extension aliases like xls, docm, ppsx resolve
                          to these)
+  --ocr <mode>           What to do with a PDF whose pages need OCR:
+                         reject (default) exits 3; hosted sends the
+                         document to Firecrawl Parse
+  --api-key <key>        Firecrawl API key for --ocr hosted, else
+                         FIRECRAWL_API_KEY, else keyless
+  --api-url <url>        Firecrawl API URL for --ocr hosted, else
+                         FIRECRAWL_API_URL, else https://api.firecrawl.dev
   -h, --help             Print this help and exit
   -V, --version          Print the version and exit
 
 The format is detected from the file content; the file extension is the
 fallback for signature-less formats (CSV). stdin has no extension, so CSV
 input from stdin needs --format csv. Scanned or image-only pages need OCR,
-which anydoc does not do: the document exits 3 naming them.
+which anydoc does not do: the document exits 3, or goes to Firecrawl Parse
+with --ocr hosted.
 
 Exit codes:
   0  success
@@ -40,7 +48,10 @@ Examples:
   anydoc slides.pptx -o slides.md
   anydoc - --format csv < data.csv
   curl -s https://example.com/paper.pdf | anydoc -
+  anydoc scan.pdf --ocr hosted
 `
+
+const OCR_MODES = ['reject', 'hosted']
 
 const USAGE_ERROR = 2
 const CONVERSION_ERROR = 1
@@ -52,7 +63,7 @@ function fail(code, message) {
 }
 
 function parseArgs(argv) {
-  const args = { input: null, output: null, format: null }
+  const args = { input: null, output: null, format: null, ocr: null, apiKey: null, apiUrl: null }
   let positionalOnly = false
   for (let i = 0; i < argv.length; i++) {
     let arg = argv[i]
@@ -97,6 +108,18 @@ function parseArgs(argv) {
       case '--format':
         args.format = value()
         break
+      case '--ocr':
+        args.ocr = value()
+        if (!OCR_MODES.includes(args.ocr)) {
+          fail(USAGE_ERROR, `invalid --ocr '${args.ocr}'; expected one of: ${OCR_MODES.join(', ')}`)
+        }
+        break
+      case '--api-key':
+        args.apiKey = value()
+        break
+      case '--api-url':
+        args.apiUrl = value()
+        break
       default:
         fail(USAGE_ERROR, `unknown option '${arg}' (see anydoc --help)`)
     }
@@ -123,7 +146,7 @@ async function main() {
 
   // Loaded after argument handling so --help and --version work even where
   // no native binding is available.
-  const { formatFromExtension, toMarkdown, toMarkdownBytes } = require('./index.js')
+  const { formatFromExtension, toMarkdown, toMarkdownBytes } = require('./anydoc.js')
 
   let format
   if (args.format !== null) {
@@ -133,14 +156,15 @@ async function main() {
     }
   }
 
+  const options = { ocr: args.ocr ?? undefined, apiKey: args.apiKey ?? undefined, apiUrl: args.apiUrl ?? undefined }
   let markdown
   try {
     if (args.input === '-') {
-      markdown = await toMarkdownBytes(await readStdin(), format)
+      markdown = await toMarkdownBytes(await readStdin(), format, options)
     } else if (format !== undefined) {
-      markdown = await toMarkdownBytes(await readFile(args.input), format)
+      markdown = await toMarkdownBytes(await readFile(args.input), format, options)
     } else {
-      markdown = await toMarkdown(args.input)
+      markdown = await toMarkdown(args.input, options)
     }
   } catch (error) {
     fail(error.code === 'needsOcr' ? NEEDS_OCR : CONVERSION_ERROR, error.message)

--- a/node/dts-header.d.ts
+++ b/node/dts-header.d.ts
@@ -23,6 +23,8 @@ export type ConvertErrorCode =
   | 'missingPart'
   /** The file could not be read, from `toMarkdown` only. */
   | 'io'
+  /** `ocr: 'hosted'` could not get the document through Firecrawl Parse. */
+  | 'hosted'
 
 /** The rejection for a PDF with pages that need OCR. */
 export interface NeedsOcrError extends Error {

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -23,6 +23,8 @@ export type ConvertErrorCode =
   | 'missingPart'
   /** The file could not be read, from `toMarkdown` only. */
   | 'io'
+  /** `ocr: 'hosted'` could not get the document through Firecrawl Parse. */
+  | 'hosted'
 
 /** The rejection for a PDF with pages that need OCR. */
 export interface NeedsOcrError extends Error {

--- a/node/package.json
+++ b/node/package.json
@@ -22,12 +22,14 @@
     "converter",
     "document"
   ],
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "anydoc.js",
+  "types": "anydoc.d.ts",
   "bin": {
     "anydoc": "cli.js"
   },
   "files": [
+    "anydoc.js",
+    "anydoc.d.ts",
     "index.js",
     "index.d.ts",
     "cli.js",

--- a/node/test.mjs
+++ b/node/test.mjs
@@ -2,6 +2,7 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -15,7 +16,7 @@ import {
   toDocument,
   toMarkdown,
   toMarkdownBytes,
-} from './index.js'
+} from './anydoc.js'
 
 const fixture = (name) => fileURLToPath(new URL(`../tests/fixtures/${name}`, import.meta.url))
 
@@ -94,6 +95,63 @@ test('a pdf with scanned pages rejects naming them instead of dropping them', as
   })
 })
 
+test('the package exports everything the native binding does', async () => {
+  const [wrapper, native] = await Promise.all([import('./anydoc.js'), import('./index.js')])
+  assert.deepEqual(Object.keys(wrapper).sort(), Object.keys(native).sort())
+})
+
+// A stand-in for api.firecrawl.dev that answers every request with `reply`
+// and records each hit as [path, whether a PDF came with it]. Runs `run`
+// keyless, whatever the environment.
+async function withHostedStub(reply, run) {
+  const hits = []
+  const server = createServer((request, response) => {
+    const chunks = []
+    request.on('data', (chunk) => chunks.push(chunk))
+    request.on('end', () => {
+      hits.push([request.url, Buffer.concat(chunks).includes('%PDF-')])
+      response.writeHead(reply.status, { 'content-type': 'application/json' })
+      response.end(JSON.stringify(reply.body))
+    })
+  })
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const url = `http://127.0.0.1:${server.address().port}`
+  const saved = { FIRECRAWL_API_URL: process.env.FIRECRAWL_API_URL, FIRECRAWL_API_KEY: process.env.FIRECRAWL_API_KEY }
+  process.env.FIRECRAWL_API_URL = url
+  delete process.env.FIRECRAWL_API_KEY
+  try {
+    await run(hits, url)
+  } finally {
+    for (const [name, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+    server.close()
+  }
+}
+
+const HOSTED = { status: 200, body: { success: true, data: { markdown: '# Read by the hosted parser\n' } } }
+
+test("ocr: 'hosted' sends a pdf with scanned pages to Firecrawl Parse, and nothing else", async () => {
+  await withHostedStub(HOSTED, async (hits) => {
+    assert.equal(await toMarkdown(MIXED, { ocr: 'hosted' }), HOSTED.body.data.markdown)
+    assert.deepEqual(hits, [['/v2/parse', true]])
+    assert.match(await toMarkdown(OUTLINE, { ocr: 'hosted' }), /^# /m)
+    assert.deepEqual(hits, [['/v2/parse', true]])
+  })
+})
+
+test('the keyless limit says to set an api key', async () => {
+  const limited = { status: 429, body: { success: false, error: 'Rate limit exceeded' } }
+  await withHostedStub(limited, async () => {
+    await assert.rejects(toMarkdown(MIXED, { ocr: 'hosted' }), (error) => {
+      assert.equal(error.code, 'hosted')
+      assert.match(error.message, /set FIRECRAWL_API_KEY/)
+      return true
+    })
+  })
+})
+
 const CLI = fileURLToPath(new URL('./cli.js', import.meta.url))
 
 // execFile rejects on a non-zero exit; the error carries code/stdout/stderr.
@@ -139,8 +197,16 @@ test('cli exits 3 when pages need OCR', async () => {
   assert.match(stderr, /^anydoc: page 2 of 2 needs OCR/)
 })
 
+test('cli --ocr hosted converts a pdf with scanned pages through Firecrawl Parse', async () => {
+  await withHostedStub(HOSTED, async (hits, url) => {
+    const { code, stdout } = await runCli([MIXED, '--ocr', 'hosted', '--api-url', url])
+    assert.equal(code, undefined)
+    assert.equal(stdout, HOSTED.body.data.markdown)
+  })
+})
+
 test('cli exits 2 on usage errors', async () => {
-  for (const args of [[], ['--frmat', 'csv', CSV], ['--format', 'nope', CSV], [OUTLINE, RICH]]) {
+  for (const args of [[], ['--frmat', 'csv', CSV], ['--format', 'nope', CSV], [OUTLINE, RICH], ['--ocr', 'cloud', MIXED]]) {
     const { code, stderr } = await runCli(args)
     assert.equal(code, 2)
     assert.match(stderr, /^anydoc: /)

--- a/python/README.md
+++ b/python/README.md
@@ -44,6 +44,14 @@ markdown = anydoc.to_markdown_bytes(data, "csv")
 document = anydoc.to_document(data)
 ```
 
+## Scanned pages
+
+anydoc converts locally and does not do OCR, so a PDF with scanned or image-only pages raises `NeedsOcrError`. Opt in with `ocr="hosted"` to send that document to [Firecrawl Parse](https://firecrawl.dev/parse). No signup needed. Set `api_key` or `FIRECRAWL_API_KEY` for higher limits.
+
+```python
+markdown = anydoc.to_markdown("scan.pdf", ocr="hosted")
+```
+
 ## Errors
 
 A conversion raises only when no complete Markdown could come out of the file. The exception type names what went wrong:
@@ -65,6 +73,7 @@ except (anydoc.EncryptedError, anydoc.UnsupportedError) as error:
 | `EncryptedError`     | Encrypted or password-protected                                     |
 | `ResourceLimitError` | Crossed a fixed safety limit (decompression, nesting, node count)   |
 | `MissingPartError`   | A part required for any meaningful output is absent                 |
+| `HostedError`        | `ocr="hosted"` could not get the document through Firecrawl Parse   |
 | `OSError`            | The file could not be read, from `to_markdown` only                 |
 
 Every conversion failure subclasses `anydoc.ConvertError`, so catching that handles all of them at once. `MalformedError.part` and `MissingPartError.part` name the package part at fault, `ResourceLimitError.limit` names the limit crossed, and `str(error)` carries the whole message. A `format` argument naming no supported format raises `ValueError`.

--- a/python/anydoc/__init__.py
+++ b/python/anydoc/__init__.py
@@ -1,5 +1,12 @@
 """Convert documents to GitHub-Flavored Markdown."""
 
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 from typing import Literal
 
 from anydoc._anydoc import (
@@ -27,9 +34,9 @@ from anydoc._anydoc import (
     format_from_extension,
     format_from_path,
     to_document,
-    to_markdown,
-    to_markdown_bytes,
 )
+from anydoc._anydoc import to_markdown as _to_markdown
+from anydoc._anydoc import to_markdown_bytes as _to_markdown_bytes
 
 Format = Literal[
     "doc", "docx", "odt", "pdf", "ppt", "pptx", "rtf", "epub", "xlsx", "ods", "odp", "csv"
@@ -37,6 +44,139 @@ Format = Literal[
 """Input format, named after the extension that identifies it. Container
 variants that share a parser (`.docm`, `.xlsm`, `.ppsx`, ...) map onto these
 via `format_from_bytes` or `format_from_extension`."""
+
+Ocr = Literal["reject", "hosted"]
+"""What happens to a PDF whose pages need OCR. `reject` (the default) raises
+`NeedsOcrError` naming the pages. `hosted` sends the whole document to
+Firecrawl Parse instead, keyless unless a key is given. Documents anydoc
+converts itself never leave the machine."""
+
+
+class HostedError(ConvertError):
+    """`ocr="hosted"` could not get the document through Firecrawl Parse."""
+
+
+def to_markdown(
+    path: "str | os.PathLike[str]",
+    *,
+    ocr: Ocr = "reject",
+    api_key: "str | None" = None,
+    api_url: "str | None" = None,
+) -> str:
+    """Convert a document file to Markdown. The format is detected from the
+    file content; the extension is the fallback for signature-less formats
+    (CSV) and unrecognizable containers.
+
+    For `ocr="hosted"`, `api_key` falls back to `FIRECRAWL_API_KEY`, then
+    keyless; `api_url` to `FIRECRAWL_API_URL`, then
+    `https://api.firecrawl.dev`."""
+    try:
+        return _to_markdown(path)
+    except NeedsOcrError:
+        if ocr != "hosted":
+            raise
+    path = Path(path)
+    return _parse_hosted(path.read_bytes(), path.name, api_key, api_url)
+
+
+def to_markdown_bytes(
+    data: "bytes | bytearray",
+    format: "Format | None" = None,
+    *,
+    ocr: Ocr = "reject",
+    api_key: "str | None" = None,
+    api_url: "str | None" = None,
+) -> str:
+    """Convert an in-memory document to Markdown. Without a format, it is
+    detected from the content, which signature-less formats (CSV) have to
+    name explicitly. `ocr`, `api_key` and `api_url` are as for
+    `to_markdown`."""
+    try:
+        return _to_markdown_bytes(data, format)
+    except NeedsOcrError:
+        if ocr != "hosted":
+            raise
+    return _parse_hosted(bytes(data), "document.pdf", api_key, api_url)
+
+
+_API_URL = "https://api.firecrawl.dev"
+_TIMEOUT_SECONDS = 300
+
+
+# The whole document goes, not only the pages that need OCR: Parse has no
+# page selection.
+def _parse_hosted(data: bytes, filename: str, api_key: "str | None", api_url: "str | None") -> str:
+    api_key = api_key or os.environ.get("FIRECRAWL_API_KEY")
+    api_url = api_url or os.environ.get("FIRECRAWL_API_URL") or _API_URL
+    url = api_url.rstrip("/") + "/v2/parse"
+    options = {"parsers": [{"type": "pdf", "mode": "auto"}], "origin": f"anydoc@{_version()}"}
+    boundary = uuid.uuid4().hex
+    request = urllib.request.Request(
+        url,
+        data=_multipart(boundary, json.dumps(options), filename, data),
+        method="POST",
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+    )
+    if api_key:
+        request.add_header("Authorization", f"Bearer {api_key}")
+    try:
+        with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:
+            status, reply = response.status, _json(response.read())
+    except urllib.error.HTTPError as error:
+        status, reply = error.code, _json(error.read())
+    except OSError as error:
+        raise HostedError(f"Firecrawl Parse: {error}") from error
+    if status != 200 or not reply.get("success"):
+        detail = reply.get("error") or f"HTTP {status}"
+        raise HostedError(_describe(status, detail, bool(api_key)))
+    markdown = (reply.get("data") or {}).get("markdown")
+    if not markdown:
+        raise HostedError("Firecrawl Parse returned no Markdown")
+    return markdown if markdown.endswith("\n") else markdown + "\n"
+
+
+def _multipart(boundary: str, options: str, filename: str, data: bytes) -> bytes:
+    filename = filename.replace('"', "_").replace("\r", "_").replace("\n", "_")
+    return b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="options"\r\n\r\n',
+            options.encode(),
+            f"\r\n--{boundary}\r\n".encode(),
+            f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'.encode(),
+            b"Content-Type: application/pdf\r\n\r\n",
+            data,
+            f"\r\n--{boundary}--\r\n".encode(),
+        ]
+    )
+
+
+def _json(body: bytes) -> dict:
+    try:
+        reply = json.loads(body)
+    except ValueError:
+        return {}
+    return reply if isinstance(reply, dict) else {}
+
+
+def _describe(status: int, detail: str, keyed: bool) -> str:
+    if status == 401:
+        return f"Firecrawl Parse rejected the API key: {detail}"
+    if status == 402:
+        return f"Firecrawl Parse is out of credits: {detail}"
+    if status == 429 and keyed:
+        return f"Firecrawl Parse rate limit reached: {detail}"
+    if status == 429:
+        return f"Firecrawl Parse keyless limit reached, set FIRECRAWL_API_KEY: {detail}"
+    return f"Firecrawl Parse: {detail}"
+
+
+def _version() -> str:
+    try:
+        return version("firecrawl-anydoc")
+    except PackageNotFoundError:
+        return "unknown"
+
 
 __all__ = [
     "Asset",
@@ -47,6 +187,7 @@ __all__ = [
     "Document",
     "EncryptedError",
     "Format",
+    "HostedError",
     "ImageSource",
     "Inline",
     "LinkTarget",
@@ -56,6 +197,7 @@ __all__ = [
     "MissingPartError",
     "NeedsOcrError",
     "Note",
+    "Ocr",
     "ResourceLimitError",
     "Style",
     "Table",

--- a/python/anydoc/__init__.py
+++ b/python/anydoc/__init__.py
@@ -106,7 +106,8 @@ _TIMEOUT_SECONDS = 300
 # The whole document goes, not only the pages that need OCR: Parse has no
 # page selection.
 def _parse_hosted(data: bytes, filename: str, api_key: "str | None", api_url: "str | None") -> str:
-    api_key = api_key or os.environ.get("FIRECRAWL_API_KEY")
+    if api_key is None:
+        api_key = os.environ.get("FIRECRAWL_API_KEY")
     api_url = api_url or os.environ.get("FIRECRAWL_API_URL") or _API_URL
     url = api_url.rstrip("/") + "/v2/parse"
     options = {"parsers": [{"type": "pdf", "mode": "auto"}], "origin": f"anydoc@{_version()}"}
@@ -129,8 +130,9 @@ def _parse_hosted(data: bytes, filename: str, api_key: "str | None", api_url: "s
     if status != 200 or not reply.get("success"):
         detail = reply.get("error") or f"HTTP {status}"
         raise HostedError(_describe(status, detail, bool(api_key)))
-    markdown = (reply.get("data") or {}).get("markdown")
-    if not markdown:
+    data = reply.get("data")
+    markdown = data.get("markdown") if isinstance(data, dict) else None
+    if not isinstance(markdown, str) or not markdown:
         raise HostedError("Firecrawl Parse returned no Markdown")
     return markdown if markdown.endswith("\n") else markdown + "\n"
 

--- a/python/tests/test_anydoc.py
+++ b/python/tests/test_anydoc.py
@@ -2,8 +2,13 @@
 
 import ast
 import io
+import json
+import os
+import threading
 import unittest
 import zipfile
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import anydoc
@@ -15,6 +20,45 @@ CSV = FIXTURES / "csv" / "sheet.csv"
 ENCRYPTED = FIXTURES / "malformed" / "encrypted--errors.odt"
 ZIPBOMB = FIXTURES / "abuse" / "zipbomb--errors.docx"
 MIXED = FIXTURES / "pdf" / "handmade-mixed.pdf"
+
+HOSTED_MARKDOWN = "# Read by the hosted parser\n"
+
+
+@contextmanager
+def hosted_stub(status, body):
+    """A stand-in for api.firecrawl.dev that answers every request with one
+    reply and records each hit as (path, whether a PDF came with it). The
+    block runs keyless, whatever the environment."""
+    hits = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            payload = self.rfile.read(int(self.headers.get("content-length", 0)))
+            hits.append((self.path, b"%PDF-" in payload))
+            reply = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(reply)))
+            self.end_headers()
+            self.wfile.write(reply)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    saved = {name: os.environ.pop(name, None) for name in ("FIRECRAWL_API_URL", "FIRECRAWL_API_KEY")}
+    os.environ["FIRECRAWL_API_URL"] = f"http://127.0.0.1:{server.server_port}"
+    try:
+        yield hits
+    finally:
+        server.shutdown()
+        server.server_close()
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 class AnydocTest(unittest.TestCase):
@@ -89,6 +133,19 @@ class AnydocTest(unittest.TestCase):
             anydoc.to_markdown_bytes(package.getvalue(), "docx")
         self.assertEqual(caught.exception.part, "word/document.xml")
 
+    def test_ocr_hosted_sends_a_pdf_with_scanned_pages_to_firecrawl_parse_and_nothing_else(self):
+        reply = {"success": True, "data": {"markdown": HOSTED_MARKDOWN}}
+        with hosted_stub(200, reply) as hits:
+            self.assertEqual(anydoc.to_markdown(MIXED, ocr="hosted"), HOSTED_MARKDOWN)
+            self.assertEqual(hits, [("/v2/parse", True)])
+            self.assertRegex(anydoc.to_markdown(OUTLINE, ocr="hosted"), r"(?m)^# ")
+            self.assertEqual(hits, [("/v2/parse", True)])
+
+    def test_the_keyless_limit_says_to_set_an_api_key(self):
+        with hosted_stub(429, {"success": False, "error": "Rate limit exceeded"}):
+            with self.assertRaisesRegex(anydoc.HostedError, "set FIRECRAWL_API_KEY"):
+                anydoc.to_markdown_bytes(MIXED.read_bytes(), ocr="hosted")
+
     def test_unreadable_files_and_bad_arguments_raise_the_python_exception(self):
         with self.assertRaises(FileNotFoundError):
             anydoc.to_markdown("no-such-file.docx")
@@ -104,8 +161,8 @@ class AnydocTest(unittest.TestCase):
         }
         exported = {name for name in dir(anydoc._anydoc) if not name.startswith("_")}
         self.assertEqual(stubbed, exported)
-        # __init__.py re-exports the whole module, plus the Format alias.
-        self.assertEqual(set(anydoc.__all__), exported | {"Format"})
+        # __init__.py re-exports the whole module, plus what it adds itself.
+        self.assertEqual(set(anydoc.__all__), exported | {"Format", "HostedError", "Ocr"})
 
 
 if __name__ == "__main__":

--- a/skills/convert-documents-to-markdown/SKILL.md
+++ b/skills/convert-documents-to-markdown/SKILL.md
@@ -22,5 +22,5 @@ Rules:
 2. The format is detected from the file content. Pass `--format <name>` only when detection cannot work: CSV from stdin, or a missing or wrong extension.
 3. Exit codes: 0 success, 1 the document could not be converted, 2 usage error, 3 pages of a PDF need OCR. Failures print one `anydoc: <message>` line to stderr. The CLI never prompts.
 4. For a large document, write to a file with `-o` and read the parts you need instead of streaming everything into context.
-5. Scanned and image-only pages need OCR, which anydoc does not do; the document exits 3 and the message names them. The hosted [Firecrawl Parse](https://firecrawl.dev/parse) API handles those.
+5. Scanned and image-only pages need OCR, which anydoc does not do, so the document exits 3. Rerun with `--ocr hosted` to send it to [Firecrawl Parse](https://firecrawl.dev/parse). No signup needed. Pass `--api-key` or set `FIRECRAWL_API_KEY` for higher limits.
 6. Inside a Node, Python, or Rust codebase, prefer the library over shelling out: `@firecrawl/anydoc` on npm, `firecrawl-anydoc` on PyPI, `anydoc` on crates.io. Each exposes the same `to_markdown` / `toMarkdown` API.


### PR DESCRIPTION
A PDF with scanned pages is a dead end from Node, Python and the CLI: `needsOcr` and nothing to do with it.

`toMarkdown` / `toMarkdownBytes` take `{ ocr: 'hosted', apiKey?, apiUrl? }`, Python takes `ocr="hosted"`, `api_key`, `api_url`, the CLI `--ocr hosted` with `--api-key` and `--api-url`. A document that fails with `needsOcr`, and only that, goes to Firecrawl Parse as one multipart POST through the runtime's own HTTP client, keyless unless a key is given. No dependency added. Failures come back as `hosted` / `HostedError`.

The Node entry point moves to `anydoc.js`, a wrapper over the generated `index.js`, with an export-parity test. Tests run against a local stub of `/v2/parse`. Stacked on #140.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a PDF with scanned pages convert through Firecrawl Parse instead of dead-ending at `needsOcr`. Node, Python, and the CLI now accept `ocr: 'hosted'` and send the document to `/v2/parse` as one multipart POST through the runtime's own HTTP client, keyless unless a key is given; no dependency added.

**Details**
- Only documents that fail with `needsOcr` are routed to Parse; anything anydoc converts itself never leaves the machine.
- Parse failures surface as `code: 'hosted'` in Node and `HostedError` in Python, including malformed or empty replies.
- An empty `apiKey` is treated as keyless.
- The Node entry point moves to `anydoc.js`, a wrapper over the generated `index.js`, with an export-parity test.
- The CLI gains `--ocr hosted` with `--api-key` and `--api-url`; tests run against a local stub of `/v2/parse`.
- Higher limits come from `apiKey`/`api_key`, `apiUrl`/`api_url`, or the `FIRECRAWL_API_KEY`/`FIRECRAWL_API_URL` env vars.

<sup>Written for commit 091b62e03f9d5f87a87c1357035c987d0a35150f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

