### PR TITLE
docs: fix Node OCR README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import { toDocument, toMarkdown, toMarkdownBytes } from '@firecrawl/anydoc';
 const markdown = await toMarkdown('report.docx');
 
 // To enable OCR:
-const markdown = await toMarkdown('report.docx', { ocr: 'hosted' );
+const ocrMarkdown = await toMarkdown('report.docx', { ocr: 'hosted' });
 
 // From bytes, with the format detected from the content:
 const fromBytes = await toMarkdownBytes(bytes);


### PR DESCRIPTION
## Summary
- fix the hosted OCR Node.js quick-start example in the top-level README so the object literal is closed correctly
- use a distinct `ocrMarkdown` variable so the full JavaScript example block parses cleanly

## Verification
- `git diff --check`
- extracted the first README `js` block and ran `node --input-type=module --check -`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Node.js OCR example in the README so the code block parses without syntax errors.

- Corrects the mismatched parenthesis in the `toMarkdown` call's object literal.
- Renames the OCR example variable to `ocrMarkdown` so it doesn't shadow the earlier `markdown` declaration.

<sup>Written for commit c52b46bd757e00d73e23c919715dc9eea767a70e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

