### PR TITLE
fix: bound parser paths reachable from a crafted document

### DIFF
--- a/src/formats/doc/lists.rs
+++ b/src/formats/doc/lists.rs
@@ -194,7 +194,12 @@ fn parse_plf_lfo(plf: &[u8], by_lsid: &HashMap<u32, [LevelDef; LEVELS]>, lists: 
     let Some(count) = get_u32(plf, 0).map(|v| v as usize) else {
         return;
     };
-    let mut lfos: Vec<(u32, usize)> = Vec::with_capacity(count);
+    // `count` is a raw header field: reserve only what the buffer could
+    // actually hold, or a lie like 0xFFFFFFFF asks the allocator for tens of
+    // gigabytes and aborts the process. The loop below still bounds the real
+    // count, since it stops as soon as a record runs past the end.
+    let capacity = count.min(plf.len().saturating_sub(4) / LFO_SIZE);
+    let mut lfos: Vec<(u32, usize)> = Vec::with_capacity(capacity);
     let mut pos = 4;
     for _ in 0..count {
         let Some(record) = plf.get(pos..).and_then(|rest| rest.get(..LFO_SIZE)) else {

--- a/src/formats/doc/mod.rs
+++ b/src/formats/doc/mod.rs
@@ -447,6 +447,13 @@ fn parse_fkps(
     }
     let n = (plc.len() - 4) / 8;
     for i in 0..n {
+        // Nothing stops every entry pointing at the same page, so `n` does
+        // not bound the run count: without this a few megabytes of table
+        // stream expand into tens of gigabytes of `Run`.
+        if runs.len() >= limits::MAX_DOC_RUNS {
+            log::debug!("doc: formatting-run budget reached; later runs are ignored");
+            break;
+        }
         let Some(pn_raw) = get_u32(plc, (n + 1) * 4 + i * 4) else {
             continue;
         };

--- a/src/formats/ppt/mod.rs
+++ b/src/formats/ppt/mod.rs
@@ -376,11 +376,22 @@ impl Extractor {
     /// Iterative container walk over an explicit stack with fixed depth and
     /// record-count bounds — nesting or record counts beyond any real
     /// presentation are attack shapes and hard-fail.
+    ///
+    /// Every descent must push onto `stack`. Nothing in here may call `walk`
+    /// again: the depth bound reads `stack.len()`, so a re-entrant call would
+    /// start a fresh stack, reset the bound to 1 and leave nesting unbounded
+    /// all the way to a stack overflow.
     fn walk(&mut self, data: &[u8]) -> Result<(), ConvertError> {
-        let mut stack: Vec<(&[u8], usize)> = vec![(data, 0)];
-        while let Some((buf, pos)) = stack.last_mut() {
+        // The flag marks a recovery-mode notes container: its segment closes
+        // when the container is exhausted, which is where the recursive call
+        // used to return to.
+        let mut stack: Vec<(&[u8], usize, bool)> = vec![(data, 0, false)];
+        while let Some((buf, pos, _)) = stack.last_mut() {
             let Some((ver_inst, rec_type, body)) = record_at(buf, *pos) else {
-                stack.pop();
+                if let Some((.., true)) = stack.pop() {
+                    self.end_segment(None);
+                    self.current_is_notes = false;
+                }
                 continue;
             };
             *pos += 8 + body.len();
@@ -402,11 +413,10 @@ impl Extractor {
                         .and_then(|(.., atom)| get_u32(atom, 0))
                         .is_some_and(|id| id & 0x8000_0000 != 0);
                     if !master {
+                        Self::check_depth(stack.len())?;
                         self.end_segment(None);
                         self.current_is_notes = true;
-                        self.walk(body)?;
-                        self.end_segment(None);
-                        self.current_is_notes = false;
+                        stack.push((body, 0, true));
                     }
                 }
                 // Notes, master, and handout containers are walked via their
@@ -415,15 +425,22 @@ impl Extractor {
                 // Only instance 0 of SlideListWithText holds slide text here.
                 0x0FF0 if ver_inst >> 4 != 0 => {}
                 _ => {
-                    if stack.len() >= limits::MAX_RECORD_DEPTH {
-                        return Err(ConvertError::ResourceLimit {
-                            limit: "max_record_depth",
-                            detail: format!("record nesting exceeds {}", limits::MAX_RECORD_DEPTH),
-                        });
-                    }
-                    stack.push((body, 0));
+                    Self::check_depth(stack.len())?;
+                    stack.push((body, 0, false));
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Hard-fail a descent that would take container nesting past
+    /// [`limits::MAX_RECORD_DEPTH`].
+    fn check_depth(depth: usize) -> Result<(), ConvertError> {
+        if depth >= limits::MAX_RECORD_DEPTH {
+            return Err(ConvertError::ResourceLimit {
+                limit: "max_record_depth",
+                detail: format!("record nesting exceeds {}", limits::MAX_RECORD_DEPTH),
+            });
         }
         Ok(())
     }
@@ -632,5 +649,57 @@ impl Extractor {
                 self.current.push(Block::Paragraph(inlines));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// `depth` NotesContainers (0x03F0), each holding the next. No NotesAtom
+    /// child, so none of them reads as the notes master.
+    fn nested_notes(depth: usize) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        for _ in 0..depth {
+            let mut outer = Vec::with_capacity(buf.len() + 8);
+            outer.extend_from_slice(&0x000Fu16.to_le_bytes()); // container
+            outer.extend_from_slice(&0x03F0u16.to_le_bytes()); // NotesContainer
+            outer.extend_from_slice(&(buf.len() as u32).to_le_bytes());
+            outer.extend_from_slice(&buf);
+            buf = outer;
+        }
+        buf
+    }
+
+    /// An OLE2 file carrying just the record stream. With no usable Current
+    /// User stream the persist directory cannot resolve, which is what puts
+    /// the extractor on the recovery path.
+    fn ppt_of(stream: &[u8]) -> Vec<u8> {
+        let mut ole = cfb::CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+        ole.create_stream("PowerPoint Document").unwrap().write_all(stream).unwrap();
+        ole.into_inner().into_inner()
+    }
+
+    /// Recovery descends into NotesContainers. That descent used to be a
+    /// recursive `walk` call, which started a fresh stack and so reset the
+    /// depth bound to 1 at every level — nesting was then bounded only by
+    /// `MAX_RECORDS` (16M), long past a stack overflow. It must hard-fail on
+    /// the shared depth bound instead.
+    #[test]
+    fn nested_notes_in_recovery_hit_the_depth_bound() {
+        let bytes = ppt_of(&nested_notes(limits::MAX_RECORD_DEPTH + 8));
+        let err = parse(&bytes).unwrap_err();
+        assert!(
+            matches!(&err, ConvertError::ResourceLimit { limit: "max_record_depth", .. }),
+            "expected max_record_depth, got {err:?}"
+        );
+    }
+
+    /// The same shape far past the bound stays an error rather than a crash.
+    #[test]
+    fn deeply_nested_notes_do_not_overflow_the_stack() {
+        let bytes = ppt_of(&nested_notes(200_000));
+        assert!(matches!(parse(&bytes), Err(ConvertError::ResourceLimit { .. })));
     }
 }

--- a/src/formats/rtf/mod.rs
+++ b/src/formats/rtf/mod.rs
@@ -9,6 +9,7 @@ mod tables;
 
 use crate::error::ConvertError;
 use crate::model::{Block, Document, Inline, Note, NoteKind, Style, inlines_are_empty};
+use crate::package::limits;
 use crate::package::xml::{Element, Node, ns};
 use crate::shared::blockstyle::{BlockStyle, StyledRun};
 use crate::shared::delta::rebase_emphasis;
@@ -292,7 +293,15 @@ impl MathState {
         MathState { depth, open: vec![(depth, math_elem("zone"))] }
     }
 
+    /// Open a nested group. Past [`limits::MAX_XML_DEPTH`] the group is
+    /// dropped and its content stays in the nearest open ancestor: this tree
+    /// is hand-built rather than produced by `parse_xml`, so nothing else
+    /// applies that bound, and the OMML serializer that consumes it recurses
+    /// once per level — as does dropping the tree.
     fn open_group(&mut self, depth: usize) {
+        if self.open.len() >= limits::MAX_XML_DEPTH {
+            return;
+        }
         self.open.push((depth, math_elem("")));
     }
 
@@ -652,6 +661,15 @@ impl<'a> Parser<'a> {
             match token {
                 Token::Open => {
                     self.flush_pending();
+                    if self.stack.len() >= limits::MAX_RTF_GROUP_DEPTH {
+                        return Err(ConvertError::ResourceLimit {
+                            limit: "max_rtf_group_depth",
+                            detail: format!(
+                                "group nesting exceeds {}",
+                                limits::MAX_RTF_GROUP_DEPTH
+                            ),
+                        });
+                    }
                     self.stack.push(self.state);
                     if self.state.capture == Capture::Math
                         && let Some(math) = &mut self.dest.math
@@ -1328,6 +1346,36 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every open group retains a character-state snapshot, so unbounded
+    /// nesting is a memory-amplification vector on its own.
+    #[test]
+    fn deep_group_nesting_hits_the_depth_bound() {
+        let mut src = String::from(r"{\rtf1\ansi ");
+        src.push_str(&"{".repeat(limits::MAX_RTF_GROUP_DEPTH + 8));
+        let err = parse(src.as_bytes()).unwrap_err();
+        assert!(
+            matches!(&err, ConvertError::ResourceLimit { limit: "max_rtf_group_depth", .. }),
+            "expected max_rtf_group_depth, got {err:?}"
+        );
+    }
+
+    /// Inside a math zone every group also opens an element. That tree is
+    /// hand-built rather than parsed, so `MAX_XML_DEPTH` has to be applied
+    /// here — the OMML serializer recurses once per level, and so does
+    /// dropping the tree.
+    #[test]
+    fn deep_math_nesting_stays_within_the_xml_depth_bound() {
+        let mut src = String::from(r"{\rtf1\ansi {\*\mmath ");
+        // Stay under the group bound so this exercises the math cap alone.
+        let groups = limits::MAX_XML_DEPTH * 2;
+        src.push_str(&"{".repeat(groups));
+        src.push('x');
+        src.push_str(&"}".repeat(groups));
+        src.push_str("}}");
+        // The contract is that it terminates without overflowing the stack.
+        let _ = parse(src.as_bytes());
+    }
 
     #[test]
     fn missing_list_table_keeps_listtext_marker() {

--- a/src/formats/sheet/numfmt.rs
+++ b/src/formats/sheet/numfmt.rs
@@ -8,6 +8,7 @@
 //! return `None` and the caller falls back to General: approximating a
 //! format silently would be worse than not applying it.
 
+use crate::package::limits;
 use std::cmp::Ordering;
 
 /// Implied format codes for built-in numFmtIds. Ids 5-8 are absent
@@ -181,6 +182,13 @@ impl NumberFormat {
         // An empty code is not the `;;;` idiom for hiding a value, it is a
         // format that says nothing, so the caller falls back to General.
         if code.is_empty() {
+            return None;
+        }
+        // Nothing upstream bounds a `formatCode` attribute, and parsing one
+        // materializes several vectors per character. Real codes are a few
+        // dozen bytes; past the cap, fall back to General rather than let a
+        // compressed archive entry amplify into gigabytes.
+        if code.len() > limits::MAX_NUMBER_FORMAT_BYTES {
             return None;
         }
         let parts = split_sections(code)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 //! its messages are not a stable API.
 
 #![warn(missing_docs)]
+// The crate parses hostile binary formats entirely in safe Rust. Make that
+// property enforced rather than incidental: a parser bug must never be able
+// to become a memory-safety bug.
+#![forbid(unsafe_code)]
 
 pub mod model;
 

--- a/src/package/limits.rs
+++ b/src/package/limits.rs
@@ -40,5 +40,23 @@ pub const MAX_ASSET_TOTAL_BYTES: usize = 128 * 1024 * 1024;
 /// Maximum nesting depth of binary record containers (legacy PPT stream).
 pub const MAX_RECORD_DEPTH: usize = 64;
 
+/// Maximum formatting runs retained from one legacy `.doc` FKP stream. The
+/// page numbers in the PLC are attacker-controlled and may all alias a single
+/// page, so the entry count on its own does not bound how many runs they
+/// yield. Past the cap formatting degrades; text extraction is unaffected.
+pub const MAX_DOC_RUNS: usize = 1_000_000;
+
+/// Maximum RTF group nesting depth. Real documents nest a few dozen groups;
+/// every open group retains a character-state snapshot, and inside a math
+/// zone it also opens an element, so unbounded nesting amplifies memory and
+/// deepens a tree that is walked and dropped recursively.
+pub const MAX_RTF_GROUP_DEPTH: usize = 1024;
+
+/// Maximum bytes of a spreadsheet number-format code. Real format codes run
+/// to a few dozen characters; the parser expands each one into several live
+/// vectors, so an unbounded `formatCode` attribute amplifies a small archive
+/// entry into gigabytes.
+pub const MAX_NUMBER_FORMAT_BYTES: usize = 4096;
+
 /// Maximum total binary records visited in one legacy record stream.
 pub const MAX_RECORDS: u64 = 16_000_000;


### PR DESCRIPTION
Five resource-exhaustion paths are reachable from untrusted input. One is a hard crash: a ~1.6 MB `.ppt` aborts the process with a stack overflow.

Each is bounded by a constant in `package::limits` now, so it returns `ResourceLimit` like every other attack shape.

### `ppt` — stack overflow (SIGSEGV)

`Extractor::walk` documents itself as *"Iterative container walk over an explicit stack with fixed depth and record-count bounds"* and enforces `MAX_RECORD_DEPTH` against `stack.len()`. But the recovery-mode `NotesContainer` branch called `self.walk(body)` again. The re-entrant call starts a fresh local `stack`, so the depth bound resets to 1 at every level and never fires — nesting ends up capped only by `MAX_RECORDS` (16M), orders of magnitude past what the real stack survives.

`recovering` is attacker-controlled: any unusable persist directory sets it.

Reproduced on `261fc25`:

```
test formats::ppt::tests::nested_notes_in_recovery_hit_the_depth_bound ... FAILED
thread '...::deeply_nested_notes_do_not_overflow_the_stack' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

The descent is a stack push carrying an end-of-segment flag now, so the `end_segment` / `current_is_notes` ordering is byte-for-byte what the recursive version did.

### `rtf` — stack overflow

Math zones build their `Element` tree through `MathState::open_group`, not `parse_xml`, so `MAX_XML_DEPTH` never applied to it. `close_groups` nests each group into its parent, making tree depth equal brace depth, and the OMML serializer (`walk_children`/`walk_elem`) recurses once per level — as does dropping the tree. Capped at construction, since a guard in the serializer would not save the recursive `Drop`.

Separately the group stack retained a `CharState` per `{` with no cap: ~10 MB of `{` → ~1 GB RSS. Now `MAX_RTF_GROUP_DEPTH`.

### `doc` — OOM and allocator abort

FKP page numbers in the PLC are masked to 22 bits and nothing stops every entry pointing at the same page, so the entry count did not bound the run list — a few MB of table stream expanded into tens of GB. Bounded by `MAX_DOC_RUNS`; formatting degrades past it, text extraction is unaffected.

`parse_plf_lfo` also sized a `Vec` straight from a raw `u32` header field, so `0xFFFFFFFF` asked the allocator for ~68 GB and hit `handle_alloc_error` → `abort()`. Clamped to what the buffer can hold; the existing loop already bounded the real count.

### `sheet` — OOM

`formatCode` has no length bound anywhere and `parse_section` materializes several vectors per character, so a compressed archive entry amplified into GBs without a worksheet cell being involved (`Styles::read` parses every `cellXfs/xf` unconditionally). Capped by `MAX_NUMBER_FORMAT_BYTES`, falling back to General.

### Also

`#![forbid(unsafe_code)]` at the crate root. The crate already had zero `unsafe` — this makes the property enforced rather than incidental. (Scoped to this crate; the parsing dependencies are unaffected.)

### Tests

Four regression tests, two of which fail on the parent commit — the `.ppt` one by aborting the test binary.

`cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` exit 0 · 300 tests pass · workspace incl. Python and WASM bindings compiles.

Happy to split this into per-format PRs, or to move the crash to a private advisory instead if you'd rather it not sit in a public diff — there is no `SECURITY.md`, and since this is a DoS in safe Rust rather than memory corruption I defaulted to the normal PR flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five resource-exhaustion paths reachable from crafted documents, including a `~1.6 MB` `.ppt` that aborts the process with a stack overflow. Each path now returns `ResourceLimit` instead of crashing or exhausting memory, matching how other attack shapes are handled.

**Bug Fixes**
- The recovery-mode notes container in `ppt` now descends via the shared bounded stack instead of re-entering `walk`, which reset the depth bound to 1 at every level and left nesting capped only by the 16M record limit.
- RTF math-zone nesting is capped at construction, since the recursive `Drop` would defeat a serializer-side guard; the group stack also gets its own cap to bound retained character-state snapshots.
- `.doc` FKP formatting runs are bounded, and `parse_plf_lfo` clamps a raw header count to the buffer length instead of reserving tens of gigabytes from a value like `0xFFFFFFFF`.
- `formatCode` longer than 4096 bytes falls back to General rather than amplifying a compressed archive entry into gigabytes.
- `#![forbid(unsafe_code)]` makes the crate's existing safe-only property enforced rather than incidental.

<sup>Written for commit f8c87cc73ab6651b8e1a9355e8332902c93e182a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

