### PR TITLE
docs: add AnyDocSwift community binding to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ let markdown = anydoc::to_markdown_bytes(&bytes, anydoc::Format::Csv)?;
 let document = anydoc::to_document(&bytes, None)?;
 ```
 
+## Community bindings
+
+- [AnyDocSwift](https://github.com/ngutech21/anydoc-swift) — Community-maintained SwiftPM binding for native macOS applications.
+
 ## OCR
 
 anydoc reads text-based PDFs locally but does no OCR, so a PDF with scanned or image-only pages fails with `NeedsOcr`. Opt in and those documents go to [Firecrawl Parse](https://firecrawl.dev/parse), which OCRs them and returns the same Markdown. No signup needed; set `FIRECRAWL_API_KEY` for higher limits.


### PR DESCRIPTION
Adds a new Community bindings section to the README and links to [AnyDocSwift](https://github.com/ngutech21/anydoc-swift), a community-maintained SwiftPM binding for native macOS applications.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Community bindings section to the README that links to AnyDocSwift, a community-maintained SwiftPM binding for native macOS applications.

<sup>Written for commit 69a8139088b22c7aaf1f2912afcf7a443c47691f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

