### PR TITLE
docs: fix WebAssembly test link

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -30,7 +30,7 @@ const document = toDocument(bytes);
 formatFromBytes(bytes); // 'docx', or undefined when nothing matches
 ```
 
-The package is built with `wasm-pack --target web`: it loads with a plain `<script type="module">` and with bundlers that handle the `new URL(..., import.meta.url)` asset pattern (Vite, webpack 5, Rollup). In Node, pass the module bytes to `initSync` instead of calling `init` (see [`test.mjs`](wasm/test.mjs)).
+The package is built with `wasm-pack --target web`: it loads with a plain `<script type="module">` and with bundlers that handle the `new URL(..., import.meta.url)` asset pattern (Vite, webpack 5, Rollup). In Node, pass the module bytes to `initSync` instead of calling `init` (see [`test.mjs`](test.mjs)).
 
 Calls are synchronous: wasm runs single-threaded on the calling thread, so convert on a worker if the main thread must stay responsive.
 


### PR DESCRIPTION
## Summary

- fix the relative link to the WebAssembly Node test in `wasm/README.md`
- keep the link relative to the README's own directory so it resolves to the tracked `wasm/test.mjs`

The current `wasm/test.mjs` target is interpreted from `wasm/README.md` as `wasm/wasm/test.mjs`, which does not exist.

## Verification

- checked all 19 relative links across the repository's 12 tracked Markdown files; zero broken links after this change
- `git diff --check`

This is documentation-only and does not change the WebAssembly package or runtime behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken WebAssembly test link in `wasm/README.md` so it resolves to the tracked `wasm/test.mjs` instead of the nonexistent `wasm/wasm/test.mjs`. Documentation-only; no runtime behavior changes.

<sup>Written for commit a6f3aba17dbc5ba54a644b9f14bf067f55d4caae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

