### PR TITLE
api: mark Format as #[non_exhaustive]

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -66,6 +66,9 @@ impl From<anydoc::Format> for Format {
             anydoc::Format::Ods => Format::ods,
             anydoc::Format::Odp => Format::odp,
             anydoc::Format::Csv => Format::csv,
+            other => unreachable!(
+                "anydoc added format {other:?}; the node bindings ship in lockstep with the core crate"
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,11 @@ use std::path::Path;
 /// Input format. Selects the parser; container variants that share a parser
 /// (docm, xlsm, ...) map onto these via [`Format::from_bytes`] or
 /// [`Format::from_extension`].
+///
+/// New formats are added over time; the enum is `#[non_exhaustive]` so
+/// downstream exhaustive matches keep compiling when variants appear.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Format {
     /// Binary Word 97-2003 (`.doc`).
     Doc,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,9 @@ use std::path::Path;
 /// (docm, xlsm, ...) map onto these via [`Format::from_bytes`] or
 /// [`Format::from_extension`].
 ///
-/// New formats are added over time; the enum is `#[non_exhaustive]` so
-/// downstream exhaustive matches keep compiling when variants appear.
+/// New formats are added over time; the enum is `#[non_exhaustive]`, so
+/// downstream callers must match it with a wildcard arm, and matches that
+/// carry one keep compiling when variants appear.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Format {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -69,6 +69,9 @@ impl From<anydoc::Format> for Format {
             anydoc::Format::Ods => Format::Ods,
             anydoc::Format::Odp => Format::Odp,
             anydoc::Format::Csv => Format::Csv,
+            other => unreachable!(
+                "anydoc added format {other:?}; the wasm bindings ship in lockstep with the core crate"
+            ),
         }
     }
 }


### PR DESCRIPTION
## Scope

Marks the public `Format` enum `#[non_exhaustive]` and adds defensive wildcard arms to the in-repo Node and WASM bindings. No conversion behavior changes.

## Motivation

#147 and #149 add `Html` and `Mhtml` variants to `Format`. Adding a variant to a public enum breaks downstream users with exhaustive `match` expressions (flagged by Cubic on #149, `src/lib.rs:50`). `#[non_exhaustive]` makes future variant additions forward-compatible: crates outside this workspace must include a wildcard arm, while references like `Format::Pdf` keep working unchanged.

## Changes

- `src/lib.rs`: `#[non_exhaustive]` on `Format` + doc note.
- `node/src/lib.rs` and `wasm/src/lib.rs`: the bindings match `anydoc::Format` exhaustively in `From<anydoc::Format>`, so each gains an explicit `other => unreachable!(...)` arm. The bindings are released in lockstep with the core crate; the arm is defensive only.
- Python bindings are untouched: they resolve format names through a lookup table, not an exhaustive match.

## Validation (full gate on the exact candidate SHA `73f851b66c8f1926221bb4e4028e833e88685ef2`, Windows, cargo 1.98.0)

- Rust: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --locked` — all clean, all suites pass.
- Node: `npm ci` / `npm run build` / `npm test` — 19 passed, 0 failed; committed `node/index.js` / `node/index.d.ts` are deterministic (zero diff after rebuild).
- WASM: wasm32 Clippy clean; `wasm-pack build wasm --release --target web --scope firecrawl`; `node --test wasm/test.mjs` — 8 passed, 0 failed.
- Python: locked Maturin release wheel, installed into a clean venv from site-packages, `python -m unittest discover -s python/tests` from the repo root — 11 tests OK.

Fixture note: this candidate is based on `main`, which intentionally does not include HTML/MHTML support, so the private real-fixture conversion matrix from the repository policy does not apply here (this PR changes no conversion logic).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the `Format` enum `#[non_exhaustive]` so future variant additions (like the in-flight `Html` and `Mhtml`) won't break downstream matches. Downstream callers must now include a wildcard arm when matching. Adds defensive `unreachable!()` arms to the Node and WASM bindings' `From<anydoc::Format>` implementations; the Python bindings are unchanged since they resolve format names via a lookup table. No conversion behavior changes.

<sup>Written for commit 7a5c8bab003fd58e6f38dcb6c93cc787c05cc086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

