### PR TITLE
fix(xml): keep a part whose text carries a bare ampersand

### DIFF
--- a/src/formats/epub/mod.rs
+++ b/src/formats/epub/mod.rs
@@ -265,4 +265,56 @@ mod tests {
             .collect::<String>();
         assert_eq!(text, "chapter text", "sixty-four itemrefs naming one part");
     }
+
+    #[test]
+    fn a_title_page_with_a_bare_ampersand_is_still_read() {
+        // A chapter that is not well-formed XML used to be dropped whole, so
+        // a title page reading "Tom & Jerry" vanished and the book appeared
+        // to start at the following chapter.
+        let parts = [
+            (
+                "META-INF/container.xml",
+                r#"<?xml version="1.0"?>
+                <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                <rootfiles><rootfile full-path="c.opf"
+                media-type="application/oebps-package+xml"/></rootfiles></container>"#,
+            ),
+            (
+                "c.opf",
+                r#"<?xml version="1.0"?>
+                <package xmlns="http://www.idpf.org/2007/opf" version="3.0"><metadata/>
+                <manifest>
+                <item id="tp" href="title.xhtml" media-type="application/xhtml+xml"/>
+                <item id="c1" href="ch1.xhtml" media-type="application/xhtml+xml"/>
+                </manifest>
+                <spine><itemref idref="tp"/><itemref idref="c1"/></spine></package>"#,
+            ),
+            (
+                "title.xhtml",
+                r#"<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml">
+                <body><p>Tom & Jerry (1940)</p></body></html>"#,
+            ),
+            (
+                "ch1.xhtml",
+                r#"<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml">
+                <body><p>chapter one</p></body></html>"#,
+            ),
+        ];
+        let mut w = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        for (name, body) in &parts {
+            w.start_file(*name, zip::write::SimpleFileOptions::default()).unwrap();
+            w.write_all(body.as_bytes()).unwrap();
+        }
+
+        let doc = parse(&w.finish().unwrap().into_inner()).unwrap();
+        let text = doc
+            .blocks
+            .iter()
+            .filter_map(|b| match b {
+                Block::Paragraph(inlines) => Some(crate::model::inlines_to_plain_text(inlines)),
+                _ => None,
+            })
+            .collect::<String>();
+        assert_eq!(text, "Tom & Jerry (1940)chapter one", "the title page opens the book");
+    }
 }

--- a/src/package/xml.rs
+++ b/src/package/xml.rs
@@ -204,6 +204,12 @@ pub fn parse_xml(bytes: &[u8]) -> Result<Element, ConvertError> {
     let utf8 = to_utf8(bytes);
     let mut reader = NsReader::from_reader(utf8.as_ref());
     reader.config_mut().check_end_names = false;
+    // A bare `&` is common in real XHTML and HTML-ish parts ("R&D", "50% &
+    // rising"). Rejecting it would discard the whole part - and the scan for
+    // the missing `;` runs to end of input, so one stray ampersand costs
+    // every element after it. Dangling ampersands stay literal text instead;
+    // well-formed references still arrive as `GeneralRef`.
+    reader.config_mut().allow_dangling_amp = true;
 
     let mut interner: HashMap<Vec<u8>, Rc<str>> = HashMap::new();
     let mut root =
@@ -626,5 +632,30 @@ mod tests {
         let root = parse_xml(&xml).unwrap();
         assert_eq!(root.text(), "leaf");
         assert_eq!(root.descendants("", "never").count(), 0);
+    }
+
+    #[test]
+    fn dangling_ampersand_stays_literal_text() {
+        // A `&` with no reference after it is not well-formed XML, but real
+        // XHTML carries it constantly. It must not cost the rest of the part:
+        // the scan for the missing `;` runs to end of input, so rejecting
+        // here would drop every element that follows.
+        for (xml, want) in [
+            (&br#"<r><p>Tom & Jerry</p><p>after</p></r>"#[..], "Tom & Jerryafter"),
+            (&br#"<r><p>R&D</p><p>after</p></r>"#[..], "R&Dafter"),
+            (&br#"<r><p>50% & rising</p><p>after</p></r>"#[..], "50% & risingafter"),
+            (&br#"<r><p>trailing &</p></r>"#[..], "trailing &"),
+        ] {
+            let root = parse_xml(xml).unwrap();
+            assert_eq!(root.text(), want, "{}", String::from_utf8_lossy(xml));
+        }
+    }
+
+    #[test]
+    fn well_formed_references_still_resolve_beside_a_dangling_one() {
+        // Leniency for the bare `&` must not stop the real references on
+        // either side of it from expanding.
+        let root = parse_xml(br#"<r><p>a &amp; b & c &#65; d &nbsp;e</p></r>"#).unwrap();
+        assert_eq!(root.text(), "a & b & c A d \u{a0}e");
     }
 }


### PR DESCRIPTION
Fixes #127.

## What happens

An `&` that begins no reference is not well-formed XML, but real XHTML carries it constantly — `Tom & Jerry`, `R&D`, `50% & rising`. quick-xml scans forward for the missing `;`, runs to end of input, and fails the read, so one stray character rejects the whole part.

In EPUB the loss is silent. Chapters load through `optional_xml_part`, which logs and skips a part that will not parse, so a title page containing an ampersand disappears and the book appears to begin at the next chapter — exactly the report in #127. The reporter guessed at the punctuation; the character that actually does it is `&`.

The same stray ampersand fails a *required* part outright in the OOXML and ODF paths, so this is not EPUB-only.

## Repro

```
title.xhtml:  <html xmlns="..."><body><p>Tom & Jerry (1940)</p></body></html>
ch1.xhtml:    <html xmlns="..."><body><p>chapter one</p></body></html>
```

Before: `chapter one`
After: `Tom & Jerry (1940)chapter one`

## The change

One line: enable quick-xml's `allow_dangling_amp`, next to the `check_end_names` leniency already set in `parse_xml`. A dangling ampersand stays literal text; well-formed references still arrive as `GeneralRef` and resolve through `resolve_entity` unchanged.

This fits what the parser already does — it recovers from mismatched and unclosed end tags rather than discarding the document — and what `resolve_entity` already does with an unknown entity name, which is to leave it as literal text.

## Tests

- `dangling_ampersand_stays_literal_text` — four shapes, including a trailing `&` at end of input, each keeping the content that follows.
- `well_formed_references_still_resolve_beside_a_dangling_one` — `&amp;`, `&#65;` and `&nbsp;` still expand with a bare `&` in the same run.
- `a_title_page_with_a_bare_ampersand_is_still_read` — the #127 symptom at the EPUB level.

All three fail on `main` and pass here. Full suite green (299 tests, no snapshot changes), `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features -D warnings` clean.

## Note, not addressed here

A raw `<` in text (`<h1>a < b</h1>`) still truncates the rest of the element — quick-xml reads it as the start of a tag. Telling a stray `<` from a real one is a different and much less contained problem, so I left it out rather than widen this change. Happy to open a separate issue if that is worth tracking.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #127 by preserving XML/XHTML parts containing a bare `&` instead of rejecting the entire part. The ampersand remains literal text, so EPUB title pages are not skipped, while valid entity references continue to resolve normally.

- Applies to the shared XML parser used by EPUB, OOXML, and ODF inputs.
- Adds coverage for embedded, trailing, and mixed valid and invalid references.
- Adds an EPUB regression test confirming content before the next chapter remains readable.

<sup>Written for commit ca9fdc82cd0286a589040e9c6c031d293b11f44d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

