### PR TITLE
fix(sheet): keep blank-looking cells out of the sheet extent

### DIFF
--- a/src/formats/sheet/xls.rs
+++ b/src/formats/sheet/xls.rs
@@ -821,9 +821,10 @@ fn txo_text(segs: &[&[u8]]) -> Option<String> {
     Some(String::from_utf16_lossy(&units))
 }
 
-/// Record only non-empty cell text, like the xlsx reader.
+/// Record only content-bearing cell text, like the xlsx reader: a cell that
+/// renders as blank must not enlarge the sheet extent.
 fn put(out: &mut SheetContent, row: u32, col: u32, text: String) {
-    if !text.is_empty() {
+    if !text.trim().is_empty() {
         out.cells.insert((row, col), text);
     }
 }

--- a/src/formats/sheet/xlsb.rs
+++ b/src/formats/sheet/xlsb.rs
@@ -272,7 +272,8 @@ fn read_sheet(
                 }
                 let fmt = xfs.get(style as usize).unwrap_or(&CellFormat::General);
                 let text = cell_text(id, &mut f, fmt, shared, date1904)?;
-                if !text.is_empty() {
+                // Blank-looking cells carry no content, like the xlsx reader.
+                if !text.trim().is_empty() {
                     out.cells.insert((r, col), text);
                 }
             }

--- a/src/formats/sheet/xlsx.rs
+++ b/src/formats/sheet/xlsx.rs
@@ -1099,4 +1099,32 @@ mod tests {
         let table = first_table(&doc);
         assert_eq!(texts(table), vec![vec!["a", "", "", "", "", "b"]], "just the content block");
     }
+
+    #[test]
+    fn a_blank_merged_row_outside_the_content_block_is_dropped() {
+        // A merge anchored on a whitespace-only cell, sitting clear of the
+        // content: nothing in it renders, so it no longer widens the sheet.
+        // The merge itself carried the only reason to keep that row.
+        let wb = one_sheet(
+            r#"<sheetData><row r="1"><c r="A1" t="inlineStr"><is><t> </t></is></c></row><row r="2"><c r="A2" t="inlineStr"><is><t>x</t></is></c><c r="B2" t="inlineStr"><is><t>y</t></is></c><c r="C2" t="inlineStr"><is><t>z</t></is></c></row></sheetData><mergeCells count="1"><mergeCell ref="A1:C1"/></mergeCells>"#,
+        );
+        let doc = parse(&wb.build()).unwrap();
+        assert_eq!(texts(first_table(&doc)), vec![vec!["x", "y", "z"]]);
+    }
+
+    #[test]
+    fn a_merged_banner_with_real_text_is_untouched() {
+        // The same shape carrying content keeps its full span: only cells
+        // that render as nothing stop counting.
+        let wb = one_sheet(
+            r#"<sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>Q3 Report</t></is></c></row><row r="2"><c r="A2" t="inlineStr"><is><t>x</t></is></c><c r="B2" t="inlineStr"><is><t>y</t></is></c><c r="C2" t="inlineStr"><is><t>z</t></is></c></row></sheetData><mergeCells count="1"><mergeCell ref="A1:C1"/></mergeCells>"#,
+        );
+        let doc = parse(&wb.build()).unwrap();
+        let table = first_table(&doc);
+        let CellSlot::Origin(cell) = &table.grid[0][0] else {
+            panic!("expected the banner merge origin at (0,0)");
+        };
+        assert_eq!(cell.col_span, 3, "the banner keeps its span");
+        assert_eq!(texts(table)[1], vec!["x", "y", "z"]);
+    }
 }

--- a/src/formats/sheet/xlsx.rs
+++ b/src/formats/sheet/xlsx.rs
@@ -297,7 +297,12 @@ fn read_sheet(
                 continue;
             }
             let text = cell_text(c, shared, styles, date1904);
-            if !text.is_empty() {
+            // Blank-looking cells carry no content and must not define the
+            // sheet: producers fill whole columns with a single space down
+            // to the sheet floor, and counting those as populated stretches
+            // the extent over millions of empty positions. A cell that
+            // renders as nothing is nothing.
+            if !text.trim().is_empty() {
                 out.cells.insert((cr, cc), text);
             }
         }
@@ -1077,5 +1082,21 @@ mod tests {
         };
         let doc = parse(&wb.build()).unwrap();
         assert_eq!(texts(first_table(&doc)), vec![vec!["14", "L/R [x] Roof", "[ ]"]]);
+    }
+
+    #[test]
+    fn whitespace_fill_does_not_stretch_the_extent() {
+        // A producer filled one column with a single space down to the sheet
+        // floor. Those cells render as nothing, so they must not enlarge the
+        // sheet: charging them would put a 67-column workbook over the grid
+        // budget on content that is not there.
+        let wb = one_sheet(
+            r#"<sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>a</t></is></c><c r="F1" t="inlineStr"><is><t>b</t></is></c></row><row r="1048576"><c r="A1048576" t="inlineStr"><is><t> </t></is></c></row></sheetData>"#,
+        );
+        // 6 columns over a million rows is past the grid budget, so before
+        // the space stopped counting this workbook did not convert at all.
+        let doc = parse(&wb.build()).unwrap();
+        let table = first_table(&doc);
+        assert_eq!(texts(table), vec![vec!["a", "", "", "", "", "b"]], "just the content block");
     }
 }


### PR DESCRIPTION
Addresses the whitespace half of #156.

## What happens

Producers fill a whole column with a single space down to the sheet floor. Those cells render as nothing, but `parse_sheet` recorded any cell whose text was not the empty string, so they counted as populated and the extent stretched from the real content block to row 1,048,576.

The grid budget is then charged for millions of positions that hold no content. A 6-column sheet with one such column needs 6,291,456 slots and does not convert at all:

```
resource limit exceeded (max_grid_slots): workbook extent covers 6291456 grid positions
```

That is the shape reported in #156, where the content block is ~67 columns wide and one column of single-space cells runs to the sheet floor.

## The change

Skip cells whose text is entirely whitespace when recording content. The extent then follows the real content block.

Applied to all three readers, which share `build_table` and therefore share the extent: `xlsx.rs`, the legacy `xls.rs` path (whose `put` already documented itself as matching the xlsx reader), and `xlsb.rs`.

## Effect on output

For a standalone whitespace cell, nothing changes — it already rendered blank, and `GridBuilder` already trimmed a trailing blank row, so the cost was paid on the budget without ever reaching the Markdown.

One shape does change. A merge anchored on a whitespace-only cell that sits entirely clear of the content block is no longer retained, so its row goes with it — an empty merged row, or trailing blank columns if the merge ran wider than the data. A merge that intersects the content block is unaffected, because `build_table` retains merges against the bounds and then widens to them; a merge carrying real text keeps its full span. Both sides are pinned by tests.

## Tests

- `whitespace_fill_does_not_stretch_the_extent` — the shape above. On `main` it fails with `max_grid_slots` at 6,291,456 positions; here the content block converts.
- `a_blank_merged_row_outside_the_content_block_is_dropped` — the behavior change, made explicit.
- `a_merged_banner_with_real_text_is_untouched` — a merged banner keeps its span, so that cannot silently regress.

Full suite green (299 tests, no snapshot changes), `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features -D warnings` clean.

## Scope

This does not close #156. That report has two shapes and this fixes one of them:

- **`max_xml_nodes`** (the tracker workbooks) is charged while parsing the sheet part into a DOM, before any of this code runs. A sheet part that decompresses to ~130 MB blows the node cap whatever the cells hold, so that one needs the sheet read without materializing every node — a much larger change I did not want to fold in here.
- **`max_grid_slots` from a lone real cell** (the `SUM(P54)` checksum at column ~16,370) is genuine content at a genuine coordinate, so it is untouched by this. Dropping outlier columns would be a heuristic and a judgement call for you rather than something to slip into a bug fix — happy to take direction if you want it pursued.
