### PR TITLE
feat: OCR scanned PDFs with a vision model via LiteLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ anydoc reads text-based PDFs locally but does no OCR, so a PDF with scanned or i
 
 Only documents that need OCR leave the machine, and the whole document goes, since Parse has no page selection. If Parse cannot convert it, Node rejects with `code: 'hosted'` and Python raises `HostedError`. `--api-url`, `apiUrl` and `api_url`, else `FIRECRAWL_API_URL`, point at another Parse deployment. The Rust crate has no `ocr` option and never makes network calls.
 
+The Python package also offers `ocr="llm"`: it rasterises the scanned pages and transcribes them with a vision model of your choosing through [LiteLLM](https://docs.litellm.ai), so the document goes only to the provider you configure. It needs the `llm` extra (`pip install "firecrawl-anydoc[llm]"`) and is configured from `ANYDOC_OCR_*` environment variables (`ANYDOC_OCR_MODEL` is required). Failures raise `LlmOcrError`. See [python/README.md](python/README.md#scanned-pages).
+
 ## Features
 
 - **One output for every format.** Each format parses into a shared document model and renders through a single Markdown serializer, so escaping, tables, heading anchors, and footnotes behave identically whether the input was a `.doc` from 2003 or a `.pptx` from yesterday.

--- a/python/README.md
+++ b/python/README.md
@@ -52,6 +52,25 @@ anydoc converts locally and does not do OCR, so a PDF with scanned or image-only
 markdown = anydoc.to_markdown("scan.pdf", ocr="hosted")
 ```
 
+Or keep the document on your own infrastructure with `ocr="llm"`: it rasterises
+the pages and transcribes them with a vision model of your choosing through
+[LiteLLM](https://docs.litellm.ai). Install the extra and point it at a model:
+
+```bash
+pip install "firecrawl-anydoc[llm]"
+export ANYDOC_OCR_MODEL=openai/gpt-4o-mini   # any LiteLLM model string
+export OPENAI_API_KEY=...                    # or ANYDOC_OCR_API_KEY
+```
+
+```python
+markdown = anydoc.to_markdown("scan.pdf", ocr="llm")
+```
+
+Configuration is read from `ANYDOC_OCR_*`: `MODEL` (required), `API_BASE`,
+`API_KEY`, `PROMPT`, `DPI` (default 200), `MAX_PAGES` (default 100),
+`PAGE_CONCURRENCY` (default 4), `TIMEOUT` (seconds, default 120). `model=`
+overrides `ANYDOC_OCR_MODEL` per call. Failures raise `LlmOcrError`.
+
 ## Errors
 
 A conversion raises only when no complete Markdown could come out of the file. The exception type names what went wrong:
@@ -74,6 +93,7 @@ except (anydoc.EncryptedError, anydoc.UnsupportedError) as error:
 | `ResourceLimitError` | Crossed a fixed safety limit (decompression, nesting, node count)   |
 | `MissingPartError`   | A part required for any meaningful output is absent                 |
 | `HostedError`        | `ocr="hosted"` could not get the document through Firecrawl Parse   |
+| `LlmOcrError`        | `ocr="llm"` could not transcribe it (missing extra/config, or model failure) |
 | `OSError`            | The file could not be read, from `to_markdown` only                 |
 
 Every conversion failure subclasses `anydoc.ConvertError`, so catching that handles all of them at once. `MalformedError.part` and `MissingPartError.part` name the package part at fault, `ResourceLimitError.limit` names the limit crossed, and `str(error)` carries the whole message. A `format` argument naming no supported format raises `ValueError`.

--- a/python/anydoc/__init__.py
+++ b/python/anydoc/__init__.py
@@ -45,15 +45,23 @@ Format = Literal[
 variants that share a parser (`.docm`, `.xlsm`, `.ppsx`, ...) map onto these
 via `format_from_bytes` or `format_from_extension`."""
 
-Ocr = Literal["reject", "hosted"]
+Ocr = Literal["reject", "hosted", "llm"]
 """What happens to a PDF whose pages need OCR. `reject` (the default) raises
 `NeedsOcrError` naming the pages. `hosted` sends the whole document to
-Firecrawl Parse instead, keyless unless a key is given. Documents anydoc
-converts itself never leave the machine."""
+Firecrawl Parse. `llm` rasterises the pages and transcribes them with a
+vision model through LiteLLM, configured from `ANYDOC_OCR_*` environment
+variables and needing the `llm` extra (`pip install firecrawl-anydoc[llm]`).
+Documents anydoc converts itself never leave the machine."""
 
 
 class HostedError(ConvertError):
     """`ocr="hosted"` could not get the document through Firecrawl Parse."""
+
+
+class LlmOcrError(ConvertError):
+    """`ocr="llm"` could not transcribe the document: the `llm` extra is not
+    installed, the `ANYDOC_OCR_*` settings are missing or invalid, or the
+    model call failed."""
 
 
 def to_markdown(
@@ -62,6 +70,7 @@ def to_markdown(
     ocr: Ocr = "reject",
     api_key: "str | None" = None,
     api_url: "str | None" = None,
+    model: "str | None" = None,
 ) -> str:
     """Convert a document file to Markdown. The format is detected from the
     file content; the extension is the fallback for signature-less formats
@@ -69,14 +78,18 @@ def to_markdown(
 
     For `ocr="hosted"`, `api_key` falls back to `FIRECRAWL_API_KEY`, then
     keyless; `api_url` to `FIRECRAWL_API_URL`, then
-    `https://api.firecrawl.dev`."""
+    `https://api.firecrawl.dev`. For `ocr="llm"`, `model` overrides
+    `ANYDOC_OCR_MODEL`; the rest of the configuration is read from
+    `ANYDOC_OCR_*`."""
     try:
         return _to_markdown(path)
     except NeedsOcrError:
-        if ocr != "hosted":
-            raise
-    path = Path(path)
-    return _parse_hosted(path.read_bytes(), path.name, api_key, api_url)
+        if ocr == "hosted":
+            path = Path(path)
+            return _parse_hosted(path.read_bytes(), path.name, api_key, api_url)
+        if ocr == "llm":
+            return _parse_llm(Path(path).read_bytes(), model)
+        raise
 
 
 def to_markdown_bytes(
@@ -86,17 +99,20 @@ def to_markdown_bytes(
     ocr: Ocr = "reject",
     api_key: "str | None" = None,
     api_url: "str | None" = None,
+    model: "str | None" = None,
 ) -> str:
     """Convert an in-memory document to Markdown. Without a format, it is
     detected from the content, which signature-less formats (CSV) have to
-    name explicitly. `ocr`, `api_key` and `api_url` are as for
+    name explicitly. `ocr`, `api_key`, `api_url` and `model` are as for
     `to_markdown`."""
     try:
         return _to_markdown_bytes(data, format)
     except NeedsOcrError:
-        if ocr != "hosted":
-            raise
-    return _parse_hosted(bytes(data), "document.pdf", api_key, api_url)
+        if ocr == "hosted":
+            return _parse_hosted(bytes(data), "document.pdf", api_key, api_url)
+        if ocr == "llm":
+            return _parse_llm(bytes(data), model)
+        raise
 
 
 _API_URL = "https://api.firecrawl.dev"
@@ -180,6 +196,20 @@ def _version() -> str:
         return "unknown"
 
 
+def _parse_llm(data: bytes, model: "str | None") -> str:
+    """Rasterise the PDF and transcribe every page with a vision model through
+    LiteLLM. Setup problems and model-call failures alike surface as
+    `LlmOcrError`."""
+    from anydoc import _llm_ocr
+
+    try:
+        return _llm_ocr.parse_llm(data, model)
+    except _llm_ocr.LlmOcrConfigError as error:
+        raise LlmOcrError(str(error)) from error
+    except Exception as error:  # noqa: BLE001 - any litellm failure becomes LlmOcrError
+        raise LlmOcrError(f"llm OCR: {error}") from error
+
+
 __all__ = [
     "Asset",
     "Block",
@@ -195,6 +225,7 @@ __all__ = [
     "LinkTarget",
     "List",
     "ListItem",
+    "LlmOcrError",
     "MalformedError",
     "MissingPartError",
     "NeedsOcrError",

--- a/python/anydoc/_llm_ocr.py
+++ b/python/anydoc/_llm_ocr.py
@@ -1,0 +1,166 @@
+"""VLM OCR for scanned PDFs, via LiteLLM.
+
+Loaded only when ``to_markdown(..., ocr="llm")`` reaches a PDF whose pages need
+OCR, so the optional dependencies (``litellm``, ``pypdfium2``,
+``pydantic-settings``) stay out of the base install. Rasterise every page to a
+PNG and ask a vision model to transcribe it to Markdown, then stitch the pages
+back together.
+
+Configuration comes from ``ANYDOC_OCR_*`` environment variables (see
+``_build_settings_class``); the API key is held as a ``SecretStr`` and only
+unwrapped at the ``litellm.completion`` call site.
+"""
+
+import base64
+import io
+from concurrent.futures import ThreadPoolExecutor
+
+DEFAULT_PROMPT = (
+    "Transcribe this page to clean GitHub-Flavored Markdown. Preserve headings, "
+    "lists, tables, and reading order. Do not add commentary or code fences "
+    "around the whole answer; output only the Markdown."
+)
+
+
+class LlmOcrConfigError(Exception):
+    """A setup problem for ``ocr="llm"``: the extra is not installed, or the
+    ``ANYDOC_OCR_*`` settings are missing or invalid. The public wrapper turns
+    this into ``LlmOcrError``."""
+
+
+def _require_deps():
+    """Import the optional dependencies, or explain the extra."""
+    try:
+        import litellm
+        import pypdfium2 as pdfium
+    except ImportError as error:
+        raise LlmOcrConfigError(
+            "ocr='llm' needs the 'llm' extra: pip install firecrawl-anydoc[llm]"
+        ) from error
+    return litellm, pdfium
+
+
+def _build_settings_class():
+    """Construct the settings model lazily: importing pydantic-settings at
+    module load would defeat the optional-dependency split."""
+    try:
+        from pydantic import Field, SecretStr
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+    except ImportError as error:
+        raise LlmOcrConfigError(
+            "ocr='llm' needs the 'llm' extra: pip install firecrawl-anydoc[llm]"
+        ) from error
+
+    class LlmOcrSettings(BaseSettings):
+        """Environment-driven configuration for ``ocr="llm"``.
+
+        Every field is read from ``ANYDOC_OCR_<NAME>``. ``model`` is required;
+        it is a LiteLLM model string such as ``openai/gpt-4o-mini`` or
+        ``anthropic/claude-sonnet-4-5``. ``api_key`` is optional here because
+        LiteLLM also reads the provider's own variable (``OPENAI_API_KEY``,
+        ``GEMINI_API_KEY``, ...)."""
+
+        model_config = SettingsConfigDict(env_prefix="ANYDOC_OCR_", extra="ignore")
+
+        model: str
+        api_base: "str | None" = None
+        api_key: "SecretStr | None" = None
+        prompt: str = DEFAULT_PROMPT
+        dpi: int = Field(default=200, gt=0)
+        max_pages: int = Field(default=100, gt=0)
+        page_concurrency: int = Field(default=4, gt=0)
+        timeout: float = Field(default=120.0, gt=0)
+
+    return LlmOcrSettings
+
+
+def _load_settings(model_override):
+    from pydantic import ValidationError
+
+    build = _build_settings_class()
+    try:
+        settings = build()
+    except ValidationError as error:
+        missing = [
+            "ANYDOC_OCR_" + "_".join(str(p) for p in err["loc"]).upper()
+            for err in error.errors()
+            if err["type"] == "missing"
+        ]
+        if missing:
+            raise LlmOcrConfigError(
+                f"ocr='llm' needs {', '.join(missing)} set (a LiteLLM model string, "
+                "e.g. ANYDOC_OCR_MODEL=openai/gpt-4o-mini)"
+            ) from error
+        raise LlmOcrConfigError(f"invalid ANYDOC_OCR_* settings: {error}") from error
+    if model_override:
+        settings.model = model_override
+    return settings
+
+
+def _rasterise(pdfium, data: bytes, dpi: int, max_pages: int) -> "list[bytes]":
+    """Every page of the PDF as PNG bytes."""
+    pdf = pdfium.PdfDocument(data)
+    try:
+        if len(pdf) > max_pages:
+            raise LlmOcrConfigError(
+                f"PDF has {len(pdf)} pages, over the ocr='llm' limit of {max_pages} "
+                "(raise ANYDOC_OCR_MAX_PAGES to allow it)"
+            )
+        pages = []
+        for page in pdf:
+            bitmap = page.render(scale=dpi / 72)
+            image = bitmap.to_pil()
+            buffer = io.BytesIO()
+            image.save(buffer, format="PNG")
+            pages.append(buffer.getvalue())
+            bitmap.close()
+            page.close()
+        return pages
+    finally:
+        pdf.close()
+
+
+def _transcribe_page(litellm, settings, png: bytes) -> str:
+    data_uri = "data:image/png;base64," + base64.b64encode(png).decode("ascii")
+    kwargs = {"timeout": settings.timeout}
+    if settings.api_base:
+        kwargs["api_base"] = settings.api_base
+    if settings.api_key is not None:
+        kwargs["api_key"] = settings.api_key.get_secret_value()
+    response = litellm.completion(
+        model=settings.model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": settings.prompt},
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                ],
+            }
+        ],
+        **kwargs,
+    )
+    return response.choices[0].message.content or ""
+
+
+def parse_llm(data: bytes, model_override: "str | None") -> str:
+    """Transcribe a scanned PDF to Markdown with a vision model. Raises
+    ``LlmOcrConfigError`` for setup problems and lets ``litellm`` exceptions
+    propagate; the public wrapper turns both into ``LlmOcrError``."""
+    litellm, pdfium = _require_deps()
+    settings = _load_settings(model_override)
+    pages = _rasterise(pdfium, data, settings.dpi, settings.max_pages)
+
+    if settings.page_concurrency == 1 or len(pages) == 1:
+        transcribed = [_transcribe_page(litellm, settings, png) for png in pages]
+    else:
+        workers = min(settings.page_concurrency, len(pages))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            transcribed = list(
+                pool.map(lambda png: _transcribe_page(litellm, settings, png), pages)
+            )
+
+    markdown = "\n\n".join(part.strip() for part in transcribed if part.strip())
+    if not markdown:
+        raise LlmOcrConfigError("the model returned no Markdown")
+    return markdown + "\n"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,11 @@ classifiers = [
 # The version comes from Cargo.toml `package.version`.
 dynamic = ["version"]
 
+# `llm` powers `to_markdown(..., ocr="llm")`: LiteLLM calls the vision model,
+# pypdfium2 rasterises the pages, pydantic-settings reads `ANYDOC_OCR_*`.
+[project.optional-dependencies]
+llm = ["litellm>=1.0", "pypdfium2>=4", "pydantic-settings>=2"]
+
 [project.urls]
 Homepage = "https://github.com/firecrawl/anydoc#readme"
 Repository = "https://github.com/firecrawl/anydoc"

--- a/python/tests/test_anydoc.py
+++ b/python/tests/test_anydoc.py
@@ -1,6 +1,7 @@
 """Smoke test: the bindings load and every entry point round-trips a fixture."""
 
 import ast
+import importlib.util
 import io
 import json
 import os
@@ -10,6 +11,8 @@ import zipfile
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 import anydoc
 
@@ -59,6 +62,38 @@ def hosted_stub(status, body):
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
+
+
+_LLM_EXTRA = all(
+    importlib.util.find_spec(name) for name in ("litellm", "pypdfium2", "pydantic_settings")
+)
+
+
+@contextmanager
+def llm_env(**values):
+    """Set `ANYDOC_OCR_*` for the block and restore whatever was there."""
+    names = {f"ANYDOC_OCR_{key.upper()}": value for key, value in values.items()}
+    saved = {name: os.environ.get(name) for name in names}
+    # Clear every ANYDOC_OCR_* so a developer's shell cannot leak in.
+    for name in list(os.environ):
+        if name.startswith("ANYDOC_OCR_"):
+            saved.setdefault(name, os.environ[name])
+            del os.environ[name]
+    os.environ.update(names)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _completion_reply(markdown):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=markdown))]
+    )
 
 
 class AnydocTest(unittest.TestCase):
@@ -146,6 +181,41 @@ class AnydocTest(unittest.TestCase):
             with self.assertRaisesRegex(anydoc.HostedError, "set FIRECRAWL_API_KEY"):
                 anydoc.to_markdown_bytes(MIXED.read_bytes(), ocr="hosted")
 
+    @unittest.skipUnless(_LLM_EXTRA, "the 'llm' extra is not installed")
+    def test_ocr_llm_transcribes_every_scanned_page_and_nothing_else(self):
+        with mock.patch("litellm.completion") as completion, llm_env(model="test/model"):
+            completion.side_effect = lambda **kw: _completion_reply(
+                f"# Page {completion.call_count}"
+            )
+            markdown = anydoc.to_markdown(MIXED, ocr="llm")
+        self.assertIn("# Page 1", markdown)
+        # handmade-mixed.pdf is two pages, so both are sent.
+        self.assertEqual(completion.call_count, 2)
+        content = completion.call_args_list[0].kwargs["messages"][0]["content"]
+        self.assertEqual(content[1]["type"], "image_url")
+        self.assertTrue(content[1]["image_url"]["url"].startswith("data:image/png;base64,"))
+
+        # A document that converts locally never reaches the model.
+        with mock.patch("litellm.completion") as completion, llm_env(model="test/model"):
+            self.assertRegex(anydoc.to_markdown(OUTLINE, ocr="llm"), r"(?m)^# ")
+            completion.assert_not_called()
+
+    @unittest.skipUnless(_LLM_EXTRA, "the 'llm' extra is not installed")
+    def test_ocr_llm_without_a_model_names_the_missing_setting(self):
+        with llm_env():
+            with self.assertRaises(anydoc.LlmOcrError) as caught:
+                anydoc.to_markdown(MIXED, ocr="llm")
+        self.assertIsInstance(caught.exception, anydoc.ConvertError)
+        self.assertIn("ANYDOC_OCR_MODEL", str(caught.exception))
+
+    @unittest.skipUnless(_LLM_EXTRA, "the 'llm' extra is not installed")
+    def test_ocr_llm_wraps_model_failures(self):
+        with mock.patch("litellm.completion", side_effect=RuntimeError("boom")), llm_env(
+            model="test/model"
+        ):
+            with self.assertRaisesRegex(anydoc.LlmOcrError, "boom"):
+                anydoc.to_markdown_bytes(MIXED.read_bytes(), ocr="llm")
+
     def test_unreadable_files_and_bad_arguments_raise_the_python_exception(self):
         with self.assertRaises(FileNotFoundError):
             anydoc.to_markdown("no-such-file.docx")
@@ -162,7 +232,10 @@ class AnydocTest(unittest.TestCase):
         exported = {name for name in dir(anydoc._anydoc) if not name.startswith("_")}
         self.assertEqual(stubbed, exported)
         # __init__.py re-exports the whole module, plus what it adds itself.
-        self.assertEqual(set(anydoc.__all__), exported | {"Format", "HostedError", "Ocr"})
+        self.assertEqual(
+            set(anydoc.__all__),
+            exported | {"Format", "HostedError", "LlmOcrError", "Ocr"},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #141 — a provider-agnostic `ocr="llm"` beside `ocr="hosted"`.

## Scope, and why Python only

#141 added `ocr="hosted"`: a PDF that needs OCR goes to Firecrawl Parse. This adds a second opt-in for people who would rather the document go to a model of their own choosing — OpenAI, Anthropic, Gemini, Bedrock, a local Ollama, a LiteLLM proxy — and not to Firecrawl.

LiteLLM's SDK is Python, so this is the Python binding only. Node and wasm keep `hosted` as their sole OCR path; the Rust core is untouched. `to_markdown` / `to_markdown_bytes` gain one `Ocr` literal and one keyword — there is no new `Format`, no `.pyi` change, no breaking change to exhaustive matches.

## Approach

It sits exactly where `_parse_hosted` sits. Native conversion runs first; on `NeedsOcrError`, if `ocr="llm"`, the new `python/anydoc/_llm_ocr.py` takes over:

- rasterise every page with `pypdfium2` at `ANYDOC_OCR_DPI` (200) to PNG
- one `litellm.completion` per page — a text instruction plus the page as a base64 `image_url` data URI
- pages run through a bounded `ThreadPoolExecutor` (`ANYDOC_OCR_PAGE_CONCURRENCY`, 4); `pool.map` keeps them in order
- join transcriptions with a blank line, one trailing newline — same normalisation as `_parse_hosted`

`litellm`, `pypdfium2` and `pydantic-settings` are an optional extra — `pip install "firecrawl-anydoc[llm]"` — imported lazily, so the base wheel keeps its zero-dependency install.

## Configuration

Environment only, read through a `pydantic-settings` model with `env_prefix="ANYDOC_OCR_"`. The API key is a `SecretStr`, unwrapped only at the `litellm.completion` call.

| var                           | default  |                                                                                 |
| ----------------------------- | -------- | ------------------------------------------------------------------------------- |
| `ANYDOC_OCR_MODEL`            | required | LiteLLM model string, e.g. `openai/gpt-4o-mini`, `ollama/llama3.2-vision`       |
| `ANYDOC_OCR_API_BASE`         |          | for proxies / local servers                                                     |
| `ANYDOC_OCR_API_KEY`          |          | optional here — LiteLLM also reads the provider's own var (`OPENAI_API_KEY`, …) |
| `ANYDOC_OCR_PROMPT`           |          | overrides the default transcription instruction                                 |
| `ANYDOC_OCR_DPI`              | 200      |                                                                                 |
| `ANYDOC_OCR_MAX_PAGES`        | 100      | refuses rather than spends                                                      |
| `ANYDOC_OCR_PAGE_CONCURRENCY` | 4        |                                                                                 |
| `ANYDOC_OCR_TIMEOUT`          | 120      | seconds, per page                                                               |

`to_markdown(..., model=...)` overrides `ANYDOC_OCR_MODEL` per call — the one non-secret knob convenient to pass inline.

## Details worth flagging

**Whole document, not only the flagged pages.** `NeedsOcrError.pages` names which pages need OCR, but a mixed PDF's text pages would be dropped if only the flagged ones went to the model, and the model reads better with the whole document. Same call `hosted` makes. The alternative — transcribe only the scanned pages and splice them into locally extracted text — is a real option I did not take; noted below.

**New error, still a `ConvertError`.** `LlmOcrError(ConvertError)`, so `except anydoc.ConvertError` keeps catching everything. It covers three setup failures — extra not installed (message is the `pip install` line), `ANYDOC_OCR_MODEL` unset (message names the var), page count over `MAX_PAGES` — and wraps any `litellm` exception as `llm OCR: <detail>`. An internal `LlmOcrConfigError` carries the setup cases out of `_llm_ocr.py`; callers only ever see `LlmOcrError`.

**No async.** `litellm` has `acompletion`, but the binding is synchronous and the GIL is released only in the Rust layer. Page fan-out is threads.

**`.pyi` untouched.** `LlmOcrError`, `Ocr` and the settings live in the Python wrapper, not the compiled module — the same split as `HostedError` today. `test_the_stubs_cover_the_module` asserts that split and is updated for the new name.

**Not wired into Node / wasm / CLI.** Deliberate — LiteLLM is Python. An OpenAI-compatible HTTP path in `node/anydoc.js` pointed at a LiteLLM proxy would be a separate PR and a different shape.

## Output

`anydoc.to_markdown("scan.pdf", ocr="llm")` returns the model's transcription verbatim, per-page results joined by a blank line and normalised to one trailing newline. Illustrative:

```markdown
# Q3 planning notes

Notes from today:

- budget signed off
- hiring on hold
```

## Tests

Three added to `python/tests/test_anydoc.py`, each `skipUnless` the extra is importable. `litellm.completion` is mocked; `pypdfium2` rasterisation and the `pydantic-settings` load run for real against the committed `handmade-mixed.pdf` fixture:

- two pages in → two `completion` calls out, each carrying an `image/png` base64 data URI; a `.docx` with `ocr="llm"` converts locally and never calls the model
- `ANYDOC_OCR_MODEL` unset → `LlmOcrError` naming it, and it is a `ConvertError`
- `completion` raising → `LlmOcrError` carrying the cause

A `llm_env` context manager saves, clears and restores `ANYDOC_OCR_*` around each, the way `hosted_stub` does for `FIRECRAWL_*`.

No integration test against a real model or a container — matching how `hosted` is tested (loopback stub, never real `api.firecrawl.dev`).

`python -m unittest discover -s tests` — 14 passed (3 new, 0 skipped with the extra installed). `cargo test` and `node --test` not run: the Rust core, Node and wasm sources are untouched.

## Registered in

`Ocr` literal, `__all__`, `python/pyproject.toml` optional-dependencies, `python/README.md` (Scanned pages + error table), root `README.md` OCR section. No `Format` variant, so no binding-stub edits and no breaking change.

## Open questions

- **Whole document vs. scanned-pages-only.** Followed `hosted`. Keeping local extraction for the text pages and sending only the flagged ones would change `_parse_llm` and the assembly test.
- **Env-only config.** `model=` is the only kwarg. Happy to surface `api_base` / `prompt` inline too; kept the surface minimal and the secret out of the signature.
- **Default prompt.** Currently "transcribe to clean GFM, preserve headings/lists/tables/reading order, output only Markdown". Open to wording you'd prefer to ship.
- **`LlmOcrSettings` visibility.** Internal right now. Export it if callers should build or introspect it.
- **Downscaling.** Pages go to the model at full raster size; a max-dimension clamp before encoding would cut token cost. Left out pending a view on defaults.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ocr="llm"` to the Python bindings so scanned PDFs can be transcribed by a vision model of your choice via LiteLLM, alongside the existing `ocr="hosted"`.

- When a PDF needs OCR, `ocr="llm"` rasterizes every page and sends each to a vision model through LiteLLM, returning the model's Markdown transcription. The whole document is sent, not just the flagged pages.
- Requires the optional `llm` extra (`pip install "firecrawl-anydoc[llm]"`) and configuration via `ANYDOC_OCR_*` environment variables (`ANYDOC_OCR_MODEL` is required). `model=` overrides `ANYDOC_OCR_MODEL` per call.
- Failures raise `LlmOcrError` (a `ConvertError`), covering missing extra, missing config, and model call failures.
- Only Python bindings change; Node, wasm, and the Rust core are untouched. No breaking changes to existing APIs.

<sup>Written for commit fdc7f3ff3c372b024ce83ce7ddc23a13ea6c1756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

