### PR TITLE
feat(eml): read RFC 5322 email messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![skills.sh](https://skills.sh/b/firecrawl/anydoc)](https://skills.sh/firecrawl/anydoc)
 
-Fast Rust library that converts documents (Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, and PDF) into clean GitHub-Flavored Markdown. Includes bindings for [Node.js](node/README.md), [Python](python/README.md), and the [browser](wasm/README.md) (WebAssembly).
+Fast Rust library that converts documents (Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, email, and PDF) into clean GitHub-Flavored Markdown. Includes bindings for [Node.js](node/README.md), [Python](python/README.md), and the [browser](wasm/README.md) (WebAssembly).
 
 Built by [Firecrawl](https://firecrawl.dev) to turn any office document into LLM-ready Markdown in single-digit milliseconds, with one consistent output no matter which format goes in. It powers [Firecrawl Parse](https://firecrawl.dev/parse), so if you'd rather not run it yourself, the hosted API gives you the same conversion plus our OCR models for the scanned pages anydoc can't read on its own.
 
@@ -167,6 +167,7 @@ Only documents that need OCR leave the machine, and the whole document goes, sin
 | Rich Text Format | `.rtf`                                                     |
 | EPUB             | `.epub`                                                    |
 | CSV              | `.csv`                                                     |
+| Email            | `.eml`                                                     |
 | PDF              | `.pdf`                                                     |
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Speed is one warm conversion per document on a Ryzen 9 9950X3D (Windows 11, 64 G
 
 ## Format detection
 
-The format is read from the file content, using the marker its specification designates: the PDF header, the RTF open group, OLE stream names, the ZIP package mimetype and content types. CSV has no such marker, so the extension or an explicit format names it instead.
+The format is read from the file content, using the marker its specification designates: the PDF header, the RTF open group, OLE stream names, the ZIP package mimetype and content types. CSV and EML have no such marker, so the extension or an explicit format names them instead.
 
 ```rust
 Format::from_bytes(&bytes); // Some(Format::Docx), or None when nothing matches
@@ -262,7 +262,7 @@ document bytes
   ├─► format detection      → content markers, not the extension
   │
   ├─► format parser          → one per format (doc, docx, ppt, pptx, xls,
-  │                            xlsx, odt/ods/odp, rtf, epub, csv)
+  │                            xlsx, odt/ods/odp, rtf, epub, csv, eml)
   │         │
   │         └─► Document     → shared model: blocks, inlines, tables,
   │                            footnotes, assets

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -84,3 +84,9 @@ name = "numfmt"
 path = "fuzz_targets/numfmt.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "eml"
+path = "fuzz_targets/eml.rs"
+test = false
+doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -5,6 +5,10 @@
 `fuzz/seeds/` holds checked-in starting inputs; `fuzz/corpus/` is the working
 directory libfuzzer writes to and is not checked in.
 
+`eml` takes whole messages, and its seeds cover a flat plaintext body and a
+multipart one, so mutation reaches the boundary walk, the transfer-decoders
+and the encoded-word reader rather than stopping at the header block.
+
 `xls`, `xlsb` and `numfmt` wrap their input in a valid container (an OLE
 compound file, an OPC package, a styles part) so mutation reaches the record
 and format-code parsers rather than dying at the container gate. `xlsx` takes

--- a/fuzz/fuzz_targets/eml.rs
+++ b/fuzz/fuzz_targets/eml.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Conversion may fail with a typed error; it must never panic, hang,
+    // or exhaust memory. Nested multipart, transfer-decoding and
+    // encoded-words all run over attacker-shaped bytes here.
+    let _ = anydoc::to_markdown_bytes(data, anydoc::Format::Eml);
+});

--- a/fuzz/seeds/eml/multipart-encoded
+++ b/fuzz/seeds/eml/multipart-encoded
@@ -1,0 +1,15 @@
+From: a@b.c
+Subject: =?utf-8?B?aGVsbG8=?=
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="bd"
+
+--bd
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+Caf=E9 r=E9sum=E9.
+--bd
+Content-Type: text/html
+
+<p>ignored</p>
+--bd--

--- a/fuzz/seeds/eml/plain
+++ b/fuzz/seeds/eml/plain
@@ -1,0 +1,8 @@
+From: a@b.c
+To: d@e.f
+Subject: hello
+Date: Mon, 1 Sep 2026 09:00:00 +1000
+
+One paragraph.
+
+And a second.

--- a/node/cli.js
+++ b/node/cli.js
@@ -32,8 +32,8 @@ Options:
   -V, --version          Print the version and exit
 
 The format is detected from the file content; the file extension is the
-fallback for signature-less formats (CSV). stdin has no extension, so CSV
-input from stdin needs --format csv. Scanned or image-only pages need OCR,
+fallback for signature-less formats (CSV, EML). stdin has no extension, so
+CSV and EML input from stdin needs --format csv or --format eml. Scanned or image-only pages need OCR,
 which anydoc does not do: the document exits 3, or goes to Firecrawl Parse
 with --ocr hosted.
 

--- a/node/cli.js
+++ b/node/cli.js
@@ -3,7 +3,7 @@
 
 const { readFile, writeFile } = require('node:fs/promises')
 
-const FORMATS = 'doc, docx, odt, pdf, ppt, pptx, rtf, epub, xlsx, ods, odp, csv'
+const FORMATS = 'doc, docx, odt, pdf, ppt, pptx, rtf, epub, xlsx, ods, odp, csv, eml'
 
 const HELP = `anydoc: convert documents to GitHub-Flavored Markdown
 

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -131,7 +131,8 @@ export declare const enum Format {
   xlsx = 'xlsx',
   ods = 'ods',
   odp = 'odp',
-  csv = 'csv'
+  csv = 'csv',
+  eml = 'eml'
 }
 
 /**

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -30,6 +30,7 @@ pub enum Format {
     ods,
     odp,
     csv,
+    eml,
 }
 
 impl From<Format> for anydoc::Format {
@@ -47,6 +48,7 @@ impl From<Format> for anydoc::Format {
             Format::ods => anydoc::Format::Ods,
             Format::odp => anydoc::Format::Odp,
             Format::csv => anydoc::Format::Csv,
+            Format::eml => anydoc::Format::Eml,
         }
     }
 }
@@ -66,6 +68,7 @@ impl From<anydoc::Format> for Format {
             anydoc::Format::Ods => Format::ods,
             anydoc::Format::Odp => Format::odp,
             anydoc::Format::Csv => Format::csv,
+            anydoc::Format::Eml => Format::eml,
         }
     }
 }

--- a/python/anydoc/__init__.py
+++ b/python/anydoc/__init__.py
@@ -39,7 +39,8 @@ from anydoc._anydoc import to_markdown as _to_markdown
 from anydoc._anydoc import to_markdown_bytes as _to_markdown_bytes
 
 Format = Literal[
-    "doc", "docx", "odt", "pdf", "ppt", "pptx", "rtf", "epub", "xlsx", "ods", "odp", "csv"
+    "doc", "docx", "odt", "pdf", "ppt", "pptx", "rtf", "epub", "xlsx", "ods", "odp", "csv",
+    "eml"
 ]
 """Input format, named after the extension that identifies it. Container
 variants that share a parser (`.docm`, `.xlsm`, `.ppsx`, ...) map onto these

--- a/python/anydoc/_anydoc.pyi
+++ b/python/anydoc/_anydoc.pyi
@@ -4,7 +4,8 @@ import os
 from typing import Literal, final
 
 Format = Literal[
-    "doc", "docx", "odt", "pdf", "ppt", "pptx", "rtf", "epub", "xlsx", "ods", "odp", "csv"
+    "doc", "docx", "odt", "pdf", "ppt", "pptx", "rtf", "epub", "xlsx", "ods", "odp", "csv",
+    "eml"
 ]
 
 class ConvertError(Exception):

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -67,7 +67,7 @@ create_exception!(
 /// Format names, as the extension that identifies each format. Container
 /// variants that share a parser (`.docm`, `.xlsm`, `.ppsx`, ...) map onto
 /// these via `format_from_bytes` or `format_from_extension`.
-const FORMATS: [(&str, anydoc::Format); 12] = [
+const FORMATS: [(&str, anydoc::Format); 13] = [
     ("doc", anydoc::Format::Doc),
     ("docx", anydoc::Format::Docx),
     ("odt", anydoc::Format::Odt),
@@ -80,6 +80,7 @@ const FORMATS: [(&str, anydoc::Format); 12] = [
     ("ods", anydoc::Format::Ods),
     ("odp", anydoc::Format::Odp),
     ("csv", anydoc::Format::Csv),
+    ("eml", anydoc::Format::Eml),
 ];
 
 fn parse_format(name: &str) -> PyResult<anydoc::Format> {

--- a/src/formats/eml.rs
+++ b/src/formats/eml.rs
@@ -1,0 +1,461 @@
+//! RFC 5322 / MIME email (`.eml`) -> model blocks.
+//!
+//! Emits the Subject as an H1 (matching the EPUB title convention), a metadata
+//! paragraph of From/To/Cc/Date, then the body. Prefers the `text/plain`
+//! alternative; a message carrying only `text/html` errors as unsupported
+//! rather than emitting markup as prose.
+//!
+//! Malformed individual parts are skipped with a log, per the crate-wide
+//! recovery policy; only a message with no usable body errors.
+
+use crate::error::ConvertError;
+use crate::model::{Block, Document, Inline, Style};
+use crate::shared::text::clean_text;
+use std::borrow::Cow;
+
+pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
+    let (headers, body) = split_headers(bytes);
+    let headers = Headers::parse(&headers);
+
+    let mut doc = Document::default();
+
+    if let Some(subject) = headers.get("subject") {
+        let subject = decode_words(&subject);
+        if !subject.trim().is_empty() {
+            doc.blocks.push(Block::Heading {
+                level: 1,
+                anchor: None,
+                content: vec![Inline::plain(clean_text(&subject))],
+            });
+        }
+    }
+
+    let meta = metadata_block(&headers);
+    if !meta.is_empty() {
+        doc.blocks.push(Block::Paragraph(meta));
+    }
+
+    let text = extract_text(&headers, body, 0)?;
+    for para in text.split("\n\n") {
+        let para = para.trim_matches('\n');
+        if para.trim().is_empty() {
+            continue;
+        }
+        let mut inlines = Vec::new();
+        for (i, line) in para.lines().enumerate() {
+            if i > 0 {
+                inlines.push(Inline::LineBreak);
+            }
+            inlines.push(Inline::plain(clean_text(line)));
+        }
+        if !inlines.is_empty() {
+            doc.blocks.push(Block::Paragraph(inlines));
+        }
+    }
+
+    Ok(doc)
+}
+
+/// Bold label + value, one line per header present.
+fn metadata_block(headers: &Headers) -> Vec<Inline> {
+    let mut out = Vec::new();
+    for (label, key) in [("From", "from"), ("To", "to"), ("Cc", "cc"), ("Date", "date")] {
+        let Some(raw) = headers.get(key) else { continue };
+        let value = decode_words(&raw);
+        if value.trim().is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(Inline::LineBreak);
+        }
+        out.push(Inline::Text {
+            text: format!("{label}: "),
+            style: Style { bold: true, ..Style::default() },
+        });
+        out.push(Inline::plain(clean_text(&value)));
+    }
+    out
+}
+
+/// Split at the first blank line: everything before is the header block.
+fn split_headers(bytes: &[u8]) -> (Vec<u8>, &[u8]) {
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\n' {
+            let rest = &bytes[i + 1..];
+            if rest.starts_with(b"\n") {
+                return (bytes[..i].to_vec(), &rest[1..]);
+            }
+            if rest.starts_with(b"\r\n") {
+                return (bytes[..i].to_vec(), &rest[2..]);
+            }
+        }
+        i += 1;
+    }
+    (bytes.to_vec(), &[])
+}
+
+struct Headers(Vec<(String, String)>);
+
+impl Headers {
+    /// Unfold continuation lines (leading whitespace) into their parent field.
+    fn parse(bytes: &[u8]) -> Self {
+        let text = String::from_utf8_lossy(bytes);
+        let mut fields: Vec<(String, String)> = Vec::new();
+        for line in text.lines() {
+            if line.starts_with(' ') || line.starts_with('\t') {
+                if let Some(last) = fields.last_mut() {
+                    last.1.push(' ');
+                    last.1.push_str(line.trim());
+                }
+                continue;
+            }
+            if let Some((name, value)) = line.split_once(':') {
+                fields.push((name.trim().to_ascii_lowercase(), value.trim().to_string()));
+            }
+        }
+        Headers(fields)
+    }
+
+    fn get(&self, name: &str) -> Option<String> {
+        self.0.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+    }
+
+    /// `Content-Type` parameter, e.g. `boundary` or `charset`.
+    fn ct_param(&self, name: &str) -> Option<String> {
+        let ct = self.get("content-type")?;
+        for part in ct.split(';').skip(1) {
+            let (k, v) = part.split_once('=')?;
+            if k.trim().eq_ignore_ascii_case(name) {
+                return Some(v.trim().trim_matches('"').to_string());
+            }
+        }
+        None
+    }
+
+    fn content_type(&self) -> String {
+        self.get("content-type")
+            .map(|c| c.split(';').next().unwrap_or("").trim().to_ascii_lowercase())
+            .unwrap_or_else(|| "text/plain".into())
+    }
+}
+
+const MAX_MIME_DEPTH: usize = 32;
+
+/// Walk the MIME tree, preferring `text/plain`.
+fn extract_text(headers: &Headers, body: &[u8], depth: usize) -> Result<String, ConvertError> {
+    if depth > MAX_MIME_DEPTH {
+        return Err(ConvertError::malformed("MIME nesting exceeds the depth limit"));
+    }
+    let ct = headers.content_type();
+
+    if ct.starts_with("multipart/") {
+        let Some(boundary) = headers.ct_param("boundary") else {
+            log::warn!("multipart part has no boundary parameter; treating as flat text");
+            return Ok(decode_body(headers, body).into_owned());
+        };
+        let parts = split_parts(body, &boundary);
+        let mut html_seen = false;
+
+        // Prefer text/plain anywhere in this level, then recurse into nested
+        // multiparts, matching the alternative-selection rule.
+        for pass in 0..2 {
+            for part in &parts {
+                let (ph, pb) = split_headers(part);
+                let ph = Headers::parse(&ph);
+                let pct = ph.content_type();
+                match pass {
+                    0 if pct == "text/plain" => {
+                        let s = decode_body(&ph, pb);
+                        if !s.trim().is_empty() {
+                            return Ok(s.into_owned());
+                        }
+                    }
+                    0 if pct == "text/html" => html_seen = true,
+                    1 if pct.starts_with("multipart/") => {
+                        if let Ok(s) = extract_text(&ph, pb, depth + 1) {
+                            if !s.trim().is_empty() {
+                                return Ok(s);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if html_seen {
+            return Err(ConvertError::Unsupported(
+                "email body is text/html only; no text/plain alternative".into(),
+            ));
+        }
+        return Err(ConvertError::Unsupported("email has no text body part".into()));
+    }
+
+    if ct == "text/html" {
+        return Err(ConvertError::Unsupported(
+            "email body is text/html only; no text/plain alternative".into(),
+        ));
+    }
+
+    let s = decode_body(headers, body);
+    if s.trim().is_empty() {
+        return Err(ConvertError::Unsupported("email has no text body".into()));
+    }
+    Ok(s.into_owned())
+}
+
+/// Split a multipart body on `--boundary` delimiters (anchored at line start).
+fn split_parts<'a>(body: &'a [u8], boundary: &str) -> Vec<&'a [u8]> {
+    let delim = format!("--{boundary}");
+    let mut parts = Vec::new();
+    let mut start: Option<usize> = None;
+    let mut pos = 0;
+
+    for line in body.split_inclusive(|&b| b == b'\n') {
+        let trimmed = line.strip_suffix(b"\n").unwrap_or(line);
+        let trimmed = trimmed.strip_suffix(b"\r").unwrap_or(trimmed);
+        if trimmed.starts_with(delim.as_bytes()) {
+            if let Some(s) = start {
+                parts.push(&body[s..pos]);
+            }
+            // Closing delimiter is `--boundary--`.
+            if trimmed.ends_with(b"--") && trimmed.len() > delim.len() {
+                return parts;
+            }
+            start = Some(pos + line.len());
+        }
+        pos += line.len();
+    }
+    if let Some(s) = start {
+        if s < body.len() {
+            parts.push(&body[s..]);
+        }
+    }
+    parts
+}
+
+/// Apply Content-Transfer-Encoding, then the declared charset.
+fn decode_body<'a>(headers: &Headers, body: &'a [u8]) -> Cow<'a, str> {
+    let cte = headers
+        .get("content-transfer-encoding")
+        .map(|s| s.trim().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    let decoded: Cow<'a, [u8]> = match cte.as_str() {
+        "quoted-printable" => Cow::Owned(decode_qp(body)),
+        "base64" => match decode_base64(body) {
+            Some(b) => Cow::Owned(b),
+            None => {
+                log::warn!("undecodable base64 body part; using raw bytes");
+                Cow::Borrowed(body)
+            }
+        },
+        _ => Cow::Borrowed(body),
+    };
+
+    let charset = headers.ct_param("charset").unwrap_or_else(|| "utf-8".into());
+    let enc = encoding_rs::Encoding::for_label(charset.as_bytes()).unwrap_or(encoding_rs::UTF_8);
+    Cow::Owned(enc.decode(&decoded).0.into_owned())
+}
+
+/// RFC 2045 quoted-printable: `=XX` hex escapes and `=`-terminated soft breaks.
+fn decode_qp(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        if input[i] != b'=' {
+            out.push(input[i]);
+            i += 1;
+            continue;
+        }
+        match input.get(i + 1) {
+            Some(b'\n') => i += 2,
+            Some(b'\r') if input.get(i + 2) == Some(&b'\n') => i += 3,
+            Some(&h) => match (hex(h), input.get(i + 2).copied().and_then(hex)) {
+                (Some(a), Some(b)) => {
+                    out.push(a * 16 + b);
+                    i += 3;
+                }
+                _ => {
+                    out.push(b'=');
+                    i += 1;
+                }
+            },
+            None => {
+                out.push(b'=');
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+fn hex(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        _ => None,
+    }
+}
+
+/// Standard base64, ignoring whitespace. `None` if the payload is malformed.
+fn decode_base64(input: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    let mut acc: u32 = 0;
+    let mut bits = 0u32;
+    for &b in input {
+        if b.is_ascii_whitespace() || b == b'=' {
+            continue;
+        }
+        let v = match b {
+            b'A'..=b'Z' => b - b'A',
+            b'a'..=b'z' => b - b'a' + 26,
+            b'0'..=b'9' => b - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            _ => return None,
+        } as u32;
+        acc = (acc << 6) | v;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((acc >> bits) as u8);
+        }
+    }
+    Some(out)
+}
+
+/// RFC 2047 encoded-words: `=?charset?B|Q?text?=`.
+fn decode_words(input: &str) -> String {
+    if !input.contains("=?") {
+        return input.to_string();
+    }
+    let mut out = String::new();
+    let mut rest = input;
+    while let Some(start) = rest.find("=?") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let Some(decoded) = decode_one_word(after) else {
+            out.push_str("=?");
+            rest = after;
+            continue;
+        };
+        let (text, consumed) = decoded;
+        out.push_str(&text);
+        rest = &after[consumed..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Decode a single `charset?enc?payload?=`, returning the text and bytes consumed.
+///
+/// The terminator is located *after* the two `?` separators: a payload's own
+/// `=XX` escapes make `?=` appear inside the word (`=?UTF-8?Q?=24=33?=`), so
+/// searching from the start finds the wrong end.
+fn decode_one_word(after: &str) -> Option<(String, usize)> {
+    let sep1 = after.find('?')?;
+    let sep2 = sep1 + 1 + after[sep1 + 1..].find('?')?;
+    let end = sep2 + 1 + after[sep2 + 1..].find("?=")?;
+    let word = &after[..end];
+    let mut it = word.splitn(3, '?');
+    let charset = it.next()?;
+    let enc = it.next()?;
+    let payload = it.next()?;
+
+    let raw = match enc.to_ascii_uppercase().as_str() {
+        "B" => decode_base64(payload.as_bytes())?,
+        // In encoded-words `_` stands for a space.
+        "Q" => decode_qp(&payload.replace('_', " ").into_bytes()),
+        _ => return None,
+    };
+    let e = encoding_rs::Encoding::for_label(charset.as_bytes()).unwrap_or(encoding_rs::UTF_8);
+    Some((e.decode(&raw).0.into_owned(), end + 2))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body_text(doc: &Document) -> String {
+        doc.blocks
+            .iter()
+            .filter_map(|b| match b {
+                Block::Paragraph(inlines) => Some(
+                    inlines
+                        .iter()
+                        .map(|i| match i {
+                            Inline::Text { text, .. } => text.as_str(),
+                            Inline::LineBreak => "\n",
+                            _ => "",
+                        })
+                        .collect::<String>(),
+                ),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+
+    #[test]
+    fn qp_decodes_escapes_and_soft_breaks() {
+        assert_eq!(decode_qp(b"a=3Db"), b"a=b");
+        assert_eq!(decode_qp(b"long=\nline"), b"longline");
+        assert_eq!(decode_qp(b"trailing="), b"trailing=");
+    }
+
+    #[test]
+    fn base64_rejects_invalid_and_decodes_valid() {
+        assert_eq!(decode_base64(b"aGVsbG8=").unwrap(), b"hello");
+        assert!(decode_base64(b"not!valid").is_none());
+    }
+
+    #[test]
+    fn encoded_words_decode_both_schemes() {
+        assert_eq!(decode_words("=?UTF-8?B?aGVsbG8=?="), "hello");
+        assert_eq!(decode_words("=?UTF-8?Q?caf=C3=A9?="), "café");
+        assert_eq!(decode_words("=?UTF-8?Q?a_b?="), "a b");
+        assert_eq!(decode_words("plain text"), "plain text");
+    }
+
+    #[test]
+    fn encoded_word_payload_containing_question_equals() {
+        // `=24` etc. put a literal `?=` inside the payload; the terminator
+        // search must start past both separators.
+        assert_eq!(decode_words("=?UTF-8?Q?=24=33=32?="), "$32");
+        assert_eq!(decode_words("a =?UTF-8?Q?=24=33?= b"), "a $3 b");
+    }
+
+    #[test]
+    fn multipart_alternative_prefers_plain() {
+        let eml = b"Subject: Test\r\nFrom: a@example.com\r\n\
+Content-Type: multipart/alternative; boundary=\"BB\"\r\n\r\n\
+--BB\r\nContent-Type: text/plain\r\n\r\nplain body\r\n\
+--BB\r\nContent-Type: text/html\r\n\r\n<p>html body</p>\r\n--BB--\r\n";
+        let doc = parse(eml).unwrap();
+        let text = body_text(&doc);
+        assert!(text.contains("plain body"), "got: {text}");
+        assert!(!text.contains("html body"), "html leaked: {text}");
+    }
+
+    #[test]
+    fn subject_becomes_heading() {
+        let doc = parse(b"Subject: Hello\r\n\r\nbody").unwrap();
+        assert!(matches!(&doc.blocks[0], Block::Heading { level: 1, .. }));
+    }
+
+    #[test]
+    fn html_only_errors_rather_than_emitting_markup() {
+        let eml = b"Subject: T\r\nContent-Type: multipart/alternative; boundary=\"B\"\r\n\r\n\
+--B\r\nContent-Type: text/html\r\n\r\n<p>only html</p>\r\n--B--\r\n";
+        let err = parse(eml).unwrap_err();
+        assert!(matches!(err, ConvertError::Unsupported(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn folded_headers_unfold() {
+        let h = Headers::parse(b"Subject: one\r\n  two\r\nFrom: x@y.z");
+        assert_eq!(h.get("subject").unwrap(), "one two");
+    }
+}

--- a/src/formats/eml.rs
+++ b/src/formats/eml.rs
@@ -248,12 +248,25 @@ fn extract_text(headers: &Headers, body: &[u8], depth: usize) -> Result<String, 
 /// RFC 2046 5.1.1: a delimiter line is exactly `--boundary`, optionally
 /// closed with `--`, followed only by whitespace. A body line that merely
 /// *starts* with the boundary (`--abcExtra`) is text, not a delimiter.
-fn is_delimiter(line: &[u8], delim: &[u8]) -> bool {
-    let Some(rest) = line.strip_prefix(delim) else {
-        return false;
+fn is_delimiter(line: &[u8], delim: &[u8]) -> Option<Delimiter> {
+    let rest = line.strip_prefix(delim)?;
+    let (rest, closing) = match rest.strip_prefix(b"--") {
+        Some(r) => (r, true),
+        None => (rest, false),
     };
-    let rest = rest.strip_prefix(b"--").unwrap_or(rest);
-    rest.iter().all(|b| b == &b' ' || b == &b'\t')
+    rest.iter().all(|b| b == &b' ' || b == &b'\t').then_some(if closing {
+        Delimiter::Closing
+    } else {
+        Delimiter::Part
+    })
+}
+
+/// Which of the two delimiter forms a line is: `--boundary` opens the next
+/// part, `--boundary--` closes the multipart and makes the rest an epilogue.
+#[derive(PartialEq)]
+enum Delimiter {
+    Part,
+    Closing,
 }
 
 fn split_parts<'a>(body: &'a [u8], boundary: &str) -> Vec<&'a [u8]> {
@@ -265,7 +278,7 @@ fn split_parts<'a>(body: &'a [u8], boundary: &str) -> Vec<&'a [u8]> {
     for line in body.split_inclusive(|&b| b == b'\n') {
         let trimmed = line.strip_suffix(b"\n").unwrap_or(line);
         let trimmed = trimmed.strip_suffix(b"\r").unwrap_or(trimmed);
-        if is_delimiter(trimmed, delim.as_bytes()) {
+        if let Some(kind) = is_delimiter(trimmed, delim.as_bytes()) {
             if let Some(s) = start {
                 // RFC 2046: the CRLF before a delimiter belongs to the
                 // delimiter, not to the part it terminates.
@@ -278,8 +291,8 @@ fn split_parts<'a>(body: &'a [u8], boundary: &str) -> Vec<&'a [u8]> {
                 }
                 parts.push(&body[s..end]);
             }
-            // Closing delimiter is `--boundary--`.
-            if trimmed.ends_with(b"--") && trimmed.len() > delim.len() {
+            // Everything after the closing delimiter is the epilogue.
+            if kind == Delimiter::Closing {
                 return parts;
             }
             start = Some(pos + line.len());
@@ -398,16 +411,19 @@ fn decode_words(input: &str) -> String {
     let mut prev_was_word = false;
     while let Some(start) = rest.find("=?") {
         let gap = &rest[..start];
-        if !(prev_was_word && !gap.is_empty() && gap.trim().is_empty()) {
-            out.push_str(gap);
-        }
         let after = &rest[start + 2..];
         let Some(decoded) = decode_one_word(after) else {
+            // Not an encoded-word after all: the gap is ordinary text.
+            out.push_str(gap);
             out.push_str("=?");
             rest = after;
             prev_was_word = false;
             continue;
         };
+        // Only whitespace separating two *decoded* words is a separator.
+        if !(prev_was_word && !gap.is_empty() && gap.trim().is_empty()) {
+            out.push_str(gap);
+        }
         let (text, consumed) = decoded;
         out.push_str(&text);
         rest = &after[consumed..];
@@ -596,6 +612,25 @@ line one\r\n--abcExtra\r\nline two\r\n\
         let text = body_text(&parse(eml).unwrap());
         assert!(text.contains("line one"), "{text:?}");
         assert!(text.contains("line two"), "{text:?}");
+    }
+
+    #[test]
+    fn padded_closing_delimiter_ends_the_multipart() {
+        // RFC 2046 5.1.1 allows trailing whitespace on a delimiter line, so
+        // `--B--  ` closes; anything after it is epilogue, not a part.
+        let eml = b"Subject: T\r\nContent-Type: multipart/mixed; boundary=\"B\"\r\n\r\n\
+--B\r\nContent-Type: application/octet-stream\r\n\r\nbinary\r\n\
+--B--  \r\n\
+--B\r\nContent-Type: text/plain\r\n\r\nepilogue\r\n\
+--B--\r\n";
+        // Nothing convertible remains once the epilogue is correctly ignored.
+        assert!(parse(eml).is_err());
+    }
+
+    #[test]
+    fn whitespace_before_a_malformed_word_is_kept() {
+        // The gap is only a separator when the token after it really decodes.
+        assert_eq!(decode_words("=?utf-8?Q?Hello?= =?bogus"), "Hello =?bogus");
     }
 
     #[test]

--- a/src/formats/eml.rs
+++ b/src/formats/eml.rs
@@ -35,23 +35,37 @@ pub fn parse(bytes: &[u8]) -> Result<Document, ConvertError> {
         doc.blocks.push(Block::Paragraph(meta));
     }
 
-    let text = extract_text(&headers, body, 0)?;
-    for para in text.split("\n\n") {
-        let para = para.trim_matches('\n');
-        if para.trim().is_empty() {
-            continue;
+    // Normalise CRLF: line iteration below keys off bare newlines, and mail
+    // bodies are CRLF throughout.
+    let text = extract_text(&headers, body, 0)?.replace("\r\n", "\n");
+
+    // A paragraph break is a run of whitespace-only lines. Senders emit lines
+    // holding a single space as often as truly empty ones, so splitting on
+    // "\n\n" alone leaves the space-only line inside the paragraph, where it
+    // renders as a hard break with nothing after it.
+    let mut para: Vec<&str> = Vec::new();
+    let flush = |para: &mut Vec<&str>, doc: &mut Document| {
+        if para.is_empty() {
+            return;
         }
         let mut inlines = Vec::new();
-        for (i, line) in para.lines().enumerate() {
+        for (i, line) in para.iter().enumerate() {
             if i > 0 {
                 inlines.push(Inline::LineBreak);
             }
             inlines.push(Inline::plain(clean_text(line)));
         }
-        if !inlines.is_empty() {
-            doc.blocks.push(Block::Paragraph(inlines));
+        doc.blocks.push(Block::Paragraph(inlines));
+        para.clear();
+    };
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            flush(&mut para, &mut doc);
+        } else {
+            para.push(line);
         }
     }
+    flush(&mut para, &mut doc);
 
     Ok(doc)
 }
@@ -99,8 +113,15 @@ struct Headers(Vec<(String, String)>);
 
 impl Headers {
     /// Unfold continuation lines (leading whitespace) into their parent field.
+    ///
+    /// Header bytes are ASCII per RFC 5322; anything else is a producer quirk.
+    /// Latin-1 round-trips those bytes instead of replacing them, which is what
+    /// mail clients do in practice.
     fn parse(bytes: &[u8]) -> Self {
-        let text = String::from_utf8_lossy(bytes);
+        let text: Cow<'_, str> = match std::str::from_utf8(bytes) {
+            Ok(s) => Cow::Borrowed(s),
+            Err(_) => Cow::Owned(encoding_rs::WINDOWS_1252.decode(bytes).0.into_owned()),
+        };
         let mut fields: Vec<(String, String)> = Vec::new();
         for line in text.lines() {
             if line.starts_with(' ') || line.starts_with('\t') {
@@ -155,6 +176,12 @@ fn extract_text(headers: &Headers, body: &[u8], depth: usize) -> Result<String, 
             return Ok(decode_body(headers, body).into_owned());
         };
         let parts = split_parts(body, &boundary);
+        if parts.is_empty() {
+            // Declared a boundary that never appears: recover by reading the
+            // body as flat text rather than reporting no body at all.
+            log::warn!("multipart boundary {boundary:?} never appears; treating body as flat text");
+            return Ok(decode_body(headers, body).into_owned());
+        }
         let mut html_seen = false;
 
         // Prefer text/plain anywhere in this level, then recurse into nested
@@ -216,7 +243,16 @@ fn split_parts<'a>(body: &'a [u8], boundary: &str) -> Vec<&'a [u8]> {
         let trimmed = trimmed.strip_suffix(b"\r").unwrap_or(trimmed);
         if trimmed.starts_with(delim.as_bytes()) {
             if let Some(s) = start {
-                parts.push(&body[s..pos]);
+                // RFC 2046: the CRLF before a delimiter belongs to the
+                // delimiter, not to the part it terminates.
+                let mut end = pos;
+                if body[s..end].ends_with(b"\n") {
+                    end -= 1;
+                    if body[s..end].ends_with(b"\r") {
+                        end -= 1;
+                    }
+                }
+                parts.push(&body[s..end]);
             }
             // Closing delimiter is `--boundary--`.
             if trimmed.ends_with(b"--") && trimmed.len() > delim.len() {
@@ -451,6 +487,50 @@ Content-Type: multipart/alternative; boundary=\"BB\"\r\n\r\n\
 --B\r\nContent-Type: text/html\r\n\r\n<p>only html</p>\r\n--B--\r\n";
         let err = parse(eml).unwrap_err();
         assert!(matches!(err, ConvertError::Unsupported(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn whitespace_only_line_separates_paragraphs() {
+        // Real senders emit a line holding one space as a paragraph break.
+        let doc = parse(b"Subject: T\r\n\r\nHey, \r\n \r\nIn today's video").unwrap();
+        let paras: Vec<_> =
+            doc.blocks.iter().filter(|b| matches!(b, Block::Paragraph(_))).collect();
+        assert_eq!(paras.len(), 2, "{paras:?}");
+        if let Some(Block::Paragraph(i)) = paras.first() {
+            assert!(!matches!(i.last(), Some(Inline::LineBreak)), "dangling break: {i:?}");
+        }
+    }
+
+    #[test]
+    fn crlf_blank_line_splits_paragraphs() {
+        let eml = b"Subject: T\r\nContent-Type: text/plain\r\n\r\none\r\n\r\ntwo";
+        let doc = parse(eml).unwrap();
+        let paras: Vec<_> =
+            doc.blocks.iter().filter(|b| matches!(b, Block::Paragraph(_))).collect();
+        assert_eq!(paras.len(), 2, "expected two paragraphs, got {paras:?}");
+    }
+
+    #[test]
+    fn non_ascii_header_bytes_survive_as_latin1() {
+        // "Café" as raw latin-1 in a header, not an encoded-word.
+        let h = Headers::parse(b"Subject: Caf\xe9 accounts");
+        assert_eq!(h.get("subject").unwrap(), "Café accounts");
+    }
+
+    #[test]
+    fn trailing_blank_line_emits_no_dangling_break() {
+        let doc = parse(b"Subject: T\r\n\r\nline one\r\n\r\n").unwrap();
+        let last = doc.blocks.last().unwrap();
+        if let Block::Paragraph(inlines) = last {
+            assert!(!matches!(inlines.last(), Some(Inline::LineBreak)), "{inlines:?}");
+        }
+    }
+
+    #[test]
+    fn declared_boundary_that_never_appears_recovers() {
+        let eml = b"Subject: T\r\nContent-Type: multipart/alternative; boundary=\"nope\"\r\n\r\nflat text";
+        let doc = parse(eml).unwrap();
+        assert!(body_text(&doc).contains("flat text"));
     }
 
     #[test]

--- a/src/formats/eml.rs
+++ b/src/formats/eml.rs
@@ -159,6 +159,14 @@ impl Headers {
             .map(|c| c.split(';').next().unwrap_or("").trim().to_ascii_lowercase())
             .unwrap_or_else(|| "text/plain".into())
     }
+
+    /// RFC 2183 disposition. An attached text part is a file the sender
+    /// enclosed, not the message body, even when it is `text/plain`.
+    fn is_attachment(&self) -> bool {
+        self.get("content-disposition").is_some_and(|d| {
+            d.split(';').next().unwrap_or("").trim().eq_ignore_ascii_case("attachment")
+        })
+    }
 }
 
 const MAX_MIME_DEPTH: usize = 32;
@@ -191,6 +199,11 @@ fn extract_text(headers: &Headers, body: &[u8], depth: usize) -> Result<String, 
                 let (ph, pb) = split_headers(part);
                 let ph = Headers::parse(&ph);
                 let pct = ph.content_type();
+                // An attachment that happens to be text/plain is not the
+                // message body; RFC 2183 disposition says which is which.
+                if ph.is_attachment() {
+                    continue;
+                }
                 match pass {
                     0 if pct == "text/plain" => {
                         let s = decode_body(&ph, pb);
@@ -232,6 +245,17 @@ fn extract_text(headers: &Headers, body: &[u8], depth: usize) -> Result<String, 
 }
 
 /// Split a multipart body on `--boundary` delimiters (anchored at line start).
+/// RFC 2046 5.1.1: a delimiter line is exactly `--boundary`, optionally
+/// closed with `--`, followed only by whitespace. A body line that merely
+/// *starts* with the boundary (`--abcExtra`) is text, not a delimiter.
+fn is_delimiter(line: &[u8], delim: &[u8]) -> bool {
+    let Some(rest) = line.strip_prefix(delim) else {
+        return false;
+    };
+    let rest = rest.strip_prefix(b"--").unwrap_or(rest);
+    rest.iter().all(|b| b == &b' ' || b == &b'\t')
+}
+
 fn split_parts<'a>(body: &'a [u8], boundary: &str) -> Vec<&'a [u8]> {
     let delim = format!("--{boundary}");
     let mut parts = Vec::new();
@@ -241,7 +265,7 @@ fn split_parts<'a>(body: &'a [u8], boundary: &str) -> Vec<&'a [u8]> {
     for line in body.split_inclusive(|&b| b == b'\n') {
         let trimmed = line.strip_suffix(b"\n").unwrap_or(line);
         let trimmed = trimmed.strip_suffix(b"\r").unwrap_or(trimmed);
-        if trimmed.starts_with(delim.as_bytes()) {
+        if is_delimiter(trimmed, delim.as_bytes()) {
             if let Some(s) = start {
                 // RFC 2046: the CRLF before a delimiter belongs to the
                 // delimiter, not to the part it terminates.
@@ -369,17 +393,25 @@ fn decode_words(input: &str) -> String {
     }
     let mut out = String::new();
     let mut rest = input;
+    // RFC 2047 6.2: linear whitespace *between* two encoded-words is a
+    // separator for the encoding, not text, and is not reproduced.
+    let mut prev_was_word = false;
     while let Some(start) = rest.find("=?") {
-        out.push_str(&rest[..start]);
+        let gap = &rest[..start];
+        if !(prev_was_word && !gap.is_empty() && gap.trim().is_empty()) {
+            out.push_str(gap);
+        }
         let after = &rest[start + 2..];
         let Some(decoded) = decode_one_word(after) else {
             out.push_str("=?");
             rest = after;
+            prev_was_word = false;
             continue;
         };
         let (text, consumed) = decoded;
         out.push_str(&text);
         rest = &after[consumed..];
+        prev_was_word = true;
     }
     out.push_str(rest);
     out
@@ -537,5 +569,41 @@ Content-Type: multipart/alternative; boundary=\"BB\"\r\n\r\n\
     fn folded_headers_unfold() {
         let h = Headers::parse(b"Subject: one\r\n  two\r\nFrom: x@y.z");
         assert_eq!(h.get("subject").unwrap(), "one two");
+    }
+
+    #[test]
+    fn attachment_does_not_displace_the_body() {
+        // multipart/mixed whose attachment is itself text/plain: the nested
+        // alternative holds the message, the attachment is an enclosed file.
+        let eml = b"Subject: T\r\nContent-Type: multipart/mixed; boundary=\"outer\"\r\n\r\n\
+--outer\r\nContent-Type: multipart/alternative; boundary=\"inner\"\r\n\r\n\
+--inner\r\nContent-Type: text/plain\r\n\r\nreal body\r\n\
+--inner--\r\n\
+--outer\r\nContent-Type: text/plain\r\nContent-Disposition: attachment; filename=\"n.txt\"\r\n\r\n\
+attached file\r\n\
+--outer--\r\n";
+        let text = body_text(&parse(eml).unwrap());
+        assert!(text.contains("real body"), "{text:?}");
+        assert!(!text.contains("attached file"), "{text:?}");
+    }
+
+    #[test]
+    fn body_line_sharing_the_boundary_prefix_is_not_a_delimiter() {
+        let eml = b"Subject: T\r\nContent-Type: multipart/mixed; boundary=\"abc\"\r\n\r\n\
+--abc\r\nContent-Type: text/plain\r\n\r\n\
+line one\r\n--abcExtra\r\nline two\r\n\
+--abc--\r\n";
+        let text = body_text(&parse(eml).unwrap());
+        assert!(text.contains("line one"), "{text:?}");
+        assert!(text.contains("line two"), "{text:?}");
+    }
+
+    #[test]
+    fn adjacent_encoded_words_join_without_the_separator() {
+        // RFC 2047 6.2: whitespace between two encoded-words is a separator
+        // for the encoding, not part of the text.
+        assert_eq!(decode_words("=?utf-8?Q?Hello?= =?utf-8?Q?World?="), "HelloWorld");
+        // ... but whitespace between a word and ordinary text is preserved.
+        assert_eq!(decode_words("=?utf-8?Q?Hello?= there"), "Hello there");
     }
 }

--- a/src/formats/eml.rs
+++ b/src/formats/eml.rs
@@ -173,10 +173,10 @@ fn extract_text(headers: &Headers, body: &[u8], depth: usize) -> Result<String, 
                     }
                     0 if pct == "text/html" => html_seen = true,
                     1 if pct.starts_with("multipart/") => {
-                        if let Ok(s) = extract_text(&ph, pb, depth + 1) {
-                            if !s.trim().is_empty() {
-                                return Ok(s);
-                            }
+                        if let Ok(s) = extract_text(&ph, pb, depth + 1)
+                            && !s.trim().is_empty()
+                        {
+                            return Ok(s);
                         }
                     }
                     _ => {}
@@ -226,10 +226,10 @@ fn split_parts<'a>(body: &'a [u8], boundary: &str) -> Vec<&'a [u8]> {
         }
         pos += line.len();
     }
-    if let Some(s) = start {
-        if s < body.len() {
-            parts.push(&body[s..]);
-        }
+    if let Some(s) = start
+        && s < body.len()
+    {
+        parts.push(&body[s..]);
     }
     parts
 }

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,6 +1,7 @@
 //! One frontend per input format; each parses bytes into the document model.
 
 mod csv;
+mod eml;
 pub mod detect;
 mod doc;
 mod docx;
@@ -20,6 +21,7 @@ pub fn parse(bytes: &[u8], format: Format) -> Result<Document, ConvertError> {
     match format {
         Format::Excel => sheet::parse(bytes),
         Format::Csv => csv::parse(bytes),
+        Format::Eml => eml::parse(bytes),
         Format::Docx => docx::parse(bytes),
         Format::Odt | Format::Ods | Format::Odp => odf::parse(bytes),
         Format::Pptx => pptx::parse(bytes),

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,10 +1,10 @@
 //! One frontend per input format; each parses bytes into the document model.
 
 mod csv;
-mod eml;
 pub mod detect;
 mod doc;
 mod docx;
+mod eml;
 mod epub;
 mod odf;
 pub mod pdf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ pub enum Format {
     /// Delimiter-separated text (`.csv`). Carries no signature, so it has to
     /// be named rather than detected.
     Csv,
+    /// RFC 5322 / MIME email (`.eml`). Header-structured text with no
+    /// signature, so it is named or resolved from the extension, never detected.
+    Eml,
 }
 
 impl Format {
@@ -84,6 +87,7 @@ impl Format {
             "ods" => Format::Ods,
             "odp" => Format::Odp,
             "csv" => Format::Csv,
+            "eml" => Format::Eml,
             _ => return None,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ impl Format {
     /// Detect the format from the content itself: the signature and identity
     /// each container specification designates (PDF header, RTF open group,
     /// OLE stream names, ZIP package mimetype/content types). Plain-text
-    /// formats (CSV) carry no signature and return `None`; so does anything
+    /// formats (CSV, EML) carry no signature and return `None`; so does anything
     /// unrecognized.
     pub fn from_bytes(bytes: &[u8]) -> Option<Format> {
         formats::detect::from_bytes(bytes)
@@ -101,7 +101,7 @@ impl Format {
 
 /// Convert a document file to Markdown. The format is detected from the
 /// file content ([`Format::from_bytes`]); the extension is the fallback for
-/// signature-less formats (CSV) and unrecognizable containers.
+/// signature-less formats (CSV, EML) and unrecognizable containers.
 pub fn to_markdown(path: impl AsRef<Path>) -> Result<String, ConvertError> {
     let path = path.as_ref();
     let bytes = std::fs::read(path)?;
@@ -116,7 +116,7 @@ pub fn to_markdown(path: impl AsRef<Path>) -> Result<String, ConvertError> {
 
 /// Convert an in-memory document to Markdown. Pass a [`Format`] to select the
 /// parser, or `None` to detect it from the content ([`Format::from_bytes`]),
-/// which signature-less formats (CSV) have to name explicitly.
+/// which signature-less formats (CSV, EML) have to name explicitly.
 pub fn to_markdown_bytes(
     bytes: &[u8],
     format: impl Into<Option<Format>>,

--- a/tests/fixtures/eml/handmade-alternative.eml
+++ b/tests/fixtures/eml/handmade-alternative.eml
@@ -1,0 +1,20 @@
+From: Ada Lovelace <ada@example.com>
+To: Charles Babbage <charles@example.org>
+Cc: notes@example.net
+Subject: Engine notes
+Date: Tue, 4 Mar 2025 09:15:00 +1100
+Content-Type: multipart/alternative; boundary="b1"
+
+--b1
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+The difference engine needs a wider carriage =E2=80=94 twenty digits, not =
+sixteen.
+
+Second paragraph, after a blank line.
+--b1
+Content-Type: text/html; charset="utf-8"
+
+<p>The difference engine needs a wider carriage.</p>
+--b1--

--- a/tests/fixtures/eml/handmade-base64-latin1.eml
+++ b/tests/fixtures/eml/handmade-base64-latin1.eml
@@ -1,0 +1,6 @@
+From: jose@example.com
+Subject: Café accounts
+Content-Type: text/plain; charset="iso-8859-1"
+Content-Transfer-Encoding: base64
+
+Q2Fm6SBjb3N0cyA1oywgbm90ZWQu

--- a/tests/fixtures/eml/handmade-encoded-words.eml
+++ b/tests/fixtures/eml/handmade-encoded-words.eml
@@ -1,0 +1,5 @@
+From: =?UTF-8?Q?Ada_Lovelace?= <ada@example.com>
+Subject: =?UTF-8?Q?=24=33=32=2C=30=30=30?= and =?UTF-8?B?Y2Fmw6k=?=
+Content-Type: text/plain; charset="utf-8"
+
+Body follows the encoded headers.

--- a/tests/fixtures/eml/handmade-folded-headers.eml
+++ b/tests/fixtures/eml/handmade-folded-headers.eml
@@ -1,0 +1,9 @@
+From: sender@example.com
+Subject: A subject that continues
+  onto a second line
+  and a third
+To: one@example.com,
+ two@example.com
+Content-Type: text/plain
+
+Short body.

--- a/tests/fixtures/eml/handmade-html-only--errors.eml
+++ b/tests/fixtures/eml/handmade-html-only--errors.eml
@@ -1,0 +1,9 @@
+From: sender@example.com
+Subject: HTML only
+Content-Type: multipart/alternative; boundary="b"
+
+--b
+Content-Type: text/html; charset="utf-8"
+
+<p>Only an HTML part exists here.</p>
+--b--

--- a/tests/fixtures/eml/handmade-missing-boundary--recovers.eml
+++ b/tests/fixtures/eml/handmade-missing-boundary--recovers.eml
@@ -1,0 +1,5 @@
+From: sender@example.com
+Subject: Boundary never appears
+Content-Type: multipart/alternative; boundary="nope"
+
+Text sitting where parts should be.

--- a/tests/fixtures/eml/handmade-mixed-attachment.eml
+++ b/tests/fixtures/eml/handmade-mixed-attachment.eml
@@ -1,0 +1,23 @@
+From: sender@example.com
+Subject: With attachment
+Content-Type: multipart/mixed; boundary="outer"
+
+--outer
+Content-Type: multipart/alternative; boundary="inner"
+
+--inner
+Content-Type: text/plain
+
+Body inside a nested alternative.
+--inner
+Content-Type: text/html
+
+<p>Body inside a nested alternative.</p>
+--inner--
+--outer
+Content-Type: application/pdf; name="report.pdf"
+Content-Disposition: attachment; filename="report.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi0xLjQK
+--outer--

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -96,6 +96,7 @@ fn fixtures_detect_from_content() {
         ("xlsb", Some(Format::Excel)),
         ("xlsx", Some(Format::Excel)),
         ("csv", None),
+        ("eml", None),
     ];
     let root = fixture_root();
     for (dir, format) in expected {

--- a/tests/snapshots/snapshots__eml__handmade-alternative.eml.snap
+++ b/tests/snapshots/snapshots__eml__handmade-alternative.eml.snap
@@ -1,0 +1,14 @@
+---
+source: tests/snapshots.rs
+expression: output
+---
+# Engine notes
+
+**From:** Ada Lovelace \<ada@example.com>\
+**To:** Charles Babbage \<charles@example.org>\
+**Cc:** notes@example.net\
+**Date:** Tue, 4 Mar 2025 09:15:00 +1100
+
+The difference engine needs a wider carriage — twenty digits, not sixteen.
+
+Second paragraph, after a blank line.

--- a/tests/snapshots/snapshots__eml__handmade-base64-latin1.eml.snap
+++ b/tests/snapshots/snapshots__eml__handmade-base64-latin1.eml.snap
@@ -1,0 +1,9 @@
+---
+source: tests/snapshots.rs
+expression: output
+---
+# Café accounts
+
+**From:** jose@example.com
+
+Café costs 5£, noted.

--- a/tests/snapshots/snapshots__eml__handmade-encoded-words.eml.snap
+++ b/tests/snapshots/snapshots__eml__handmade-encoded-words.eml.snap
@@ -1,0 +1,9 @@
+---
+source: tests/snapshots.rs
+expression: output
+---
+# $32,000 and café
+
+**From:** Ada Lovelace \<ada@example.com>
+
+Body follows the encoded headers.

--- a/tests/snapshots/snapshots__eml__handmade-folded-headers.eml.snap
+++ b/tests/snapshots/snapshots__eml__handmade-folded-headers.eml.snap
@@ -1,0 +1,10 @@
+---
+source: tests/snapshots.rs
+expression: output
+---
+# A subject that continues onto a second line and a third
+
+**From:** sender@example.com\
+**To:** one@example.com, two@example.com
+
+Short body.

--- a/tests/snapshots/snapshots__eml__handmade-html-only--errors.eml.snap
+++ b/tests/snapshots/snapshots__eml__handmade-html-only--errors.eml.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshots.rs
+expression: output
+---
+ERROR: unsupported input: email body is text/html only; no text/plain alternative

--- a/tests/snapshots/snapshots__eml__handmade-missing-boundary--recovers.eml.snap
+++ b/tests/snapshots/snapshots__eml__handmade-missing-boundary--recovers.eml.snap
@@ -1,0 +1,9 @@
+---
+source: tests/snapshots.rs
+expression: output
+---
+# Boundary never appears
+
+**From:** sender@example.com
+
+Text sitting where parts should be.

--- a/tests/snapshots/snapshots__eml__handmade-mixed-attachment.eml.snap
+++ b/tests/snapshots/snapshots__eml__handmade-mixed-attachment.eml.snap
@@ -1,0 +1,9 @@
+---
+source: tests/snapshots.rs
+expression: output
+---
+# With attachment
+
+**From:** sender@example.com
+
+Body inside a nested alternative.

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -32,6 +32,7 @@ pub enum Format {
     Ods = "ods",
     Odp = "odp",
     Csv = "csv",
+    Eml = "eml",
 }
 
 impl From<Format> for anydoc::Format {
@@ -49,6 +50,7 @@ impl From<Format> for anydoc::Format {
             Format::Ods => anydoc::Format::Ods,
             Format::Odp => anydoc::Format::Odp,
             Format::Csv => anydoc::Format::Csv,
+            Format::Eml => anydoc::Format::Eml,
             Format::__Invalid => unreachable!("wasm-bindgen rejects invalid enum strings"),
         }
     }
@@ -69,6 +71,7 @@ impl From<anydoc::Format> for Format {
             anydoc::Format::Ods => Format::Ods,
             anydoc::Format::Odp => Format::Odp,
             anydoc::Format::Csv => Format::Csv,
+            anydoc::Format::Eml => Format::Eml,
         }
     }
 }


### PR DESCRIPTION
Closes half of #128: `.eml` only. `.msg` is #160, from @vaibhavdabas16 — independent frontends, either order.

## Shape

Hand-rolled MIME on `std` + `encoding_rs`, no new dependencies. Follows `csv.rs`: `parse(bytes) -> Result<Document, ConvertError>`, produces the document model, does not touch the Markdown writer.

- RFC 5322 headers, continuation lines unfolded
- multipart traversal, depth-capped, prefers `text/plain`
- quoted-printable and base64 transfer-decoding
- RFC 2047 encoded-words, both B and Q
- charset via `encoding_rs`, mirroring `csv.rs::decode`
- Subject as H1, From/To/Cc/Date as a metadata paragraph
- extension-only detection, no `detect.rs` entry, per the CSV precedent for signature-less text formats

Registered in the node, wasm and python enums and in `node/cli.js` FORMATS.

A body that is `text/html` with no `text/plain` alternative returns `Unsupported` rather than emitting markup as prose. That case wants #52 or #53 landing first; I did not want to guess at HTML here.

## Validation

142 real `.eml` files, Outlook/Exchange via Mimecast: 141 convert, median 4.0 ms.

The one failure is a calendar invite whose `text/plain` part is 2 bytes and whose content is `text/calendar`. It returns `Unsupported` rather than emitting the 2 bytes. Correct as far as I can tell, but it is a judgement call — happy to extract it instead if you would rather.

Running the whole corpus, rather than spot-checking, is what made this worth trusting. It surfaced an RFC 2047 bug I would not have invented a test for: `decode_one_word` looked for the terminator `?=` from the start of the word, but a payload's own `=XX` escapes can put a literal `?=` inside it, so the search landed early and parsing bailed, leaving raw encoded words in the subject. Fixed by locating the terminator after both `?` separators, with a regression test. Post-fix the corpus has zero undecoded escapes and zero U+FFFD.

That corpus is private, so the fixtures are synthetic: seven handmade files under `tests/fixtures/eml/`, plus the `fixtures_detect_from_content` entry. Writing them turned up four more bugs I had missed against real mail, the worst being that a whitespace-only line (one space, not empty) did not break a paragraph, so it rendered as a hard break with nothing after it. 3267 occurrences across the corpus, now zero.

Fuzzed as well, since the parser walks attacker-shaped bytes: 3,088,842 executions over the two seeds, no crashes, no hangs, no leaks.

Checks, on this branch against v0.2.4:

- `cargo test --locked` — 309 passed, 1 ignored (13 new unit tests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy -p anydoc-wasm --target wasm32-unknown-unknown -- -D warnings`
- `cargo fmt --all --check`
- `cargo +nightly fuzz run eml` — 3,088,842 executions, clean

## Two notes for review

**`detect.rs`.** I left `.eml` on extension-only detection, reading the CSV precedent in the README ("CSV has no such marker, so the extension or an explicit format names it instead") as the rule for signature-less text formats. #160 chose a content-sniff entry for `.msg`, which is a different case — OLE has a real signature. If you would rather `.eml` sniffed too, say so and I will add it; I did not want to invent a heuristic that `detect.rs` warns against.

**Shared helper.** If both this and #160 land, each frontend carries its own envelope-and-body rendering. @vaibhavdabas16 offered to factor that out as a follow-up once the second one is in, and that is the right shape — he has the clearer view of both. I am happy to take it instead if he would rather not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RFC 5322/MIME `.eml` conversion, closing the `.eml` half of #128. Previously unsupported, messages now convert to Markdown with the Subject as an H1, sender metadata, and a `text/plain` body preferred over `text/html`.

**Behavior**
- Supports folded headers, RFC 2047 encoded words, quoted-printable and base64 bodies, charsets, and nested multipart messages without new dependencies.
- Excludes attachments, recovers missing boundaries as flat text, and returns `Unsupported` for HTML-only messages.
- Uses extension or explicit-format selection because EML has no content signature, and exposes the format in the Rust, Node, Python, WASM, and CLI APIs.
- Handles padded closing boundaries without consuming the epilogue and preserves whitespace before malformed encoded-word candidates.

**Validation**
- Adds fixtures, snapshots, unit tests, and fuzz coverage; 141 of 142 real Outlook/Exchange messages convert with a 4 ms median, and 3M+ fuzz executions completed cleanly.

<sup>Written for commit af00979796307ee5059b003927a3fde1f4139d00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/anydoc/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

